### PR TITLE
[FEATURE] Camera sensors: multi-modality, first-class pipeline, and shared vis.Camera

### DIFF
--- a/genesis/engine/entities/base_entity.py
+++ b/genesis/engine/entities/base_entity.py
@@ -132,8 +132,8 @@ class Entity(RBC):
         Returns
         -------
         dict[Type[Sensor], torch.Tensor]
-            For each sensor class with at least one sensor on this entity, a tensor of shape
-            (B, [history,] entity_cache_size_for_class).
+            For each ring-pipeline sensor class with at least one sensor on this entity, a tensor of shape
+            (B, [history,] entity_cache_size_for_class). Camera sensors are excluded; read them via ``camera.read()``.
         """
         return self._sim._sensor_manager.read_sensors(entity_idx=self._idx, envs_idx=envs_idx)
 

--- a/genesis/engine/entities/base_entity.py
+++ b/genesis/engine/entities/base_entity.py
@@ -119,10 +119,11 @@ class Entity(RBC):
     @gs.assert_built
     def read_sensors(self, envs_idx=None) -> "dict[type[Sensor], torch.Tensor]":
         """
-        Read every sensor attached to this entity as a tensor per sensor class.
+        Read every **vector** sensor attached to this entity as a tensor per sensor class.
 
-        Always returns a fresh tensor independent of the internal sensor storage; the caller is free to mutate the
-        result.
+        Batched reader for vector-shaped sensors on this entity. Camera sensors are not included - read them via
+        ``camera.read()`` or all at once via :meth:`read_cameras`. Always returns a fresh tensor independent of the
+        internal sensor storage; the caller is free to mutate the result.
 
         Parameters
         ----------
@@ -132,10 +133,23 @@ class Entity(RBC):
         Returns
         -------
         dict[Type[Sensor], torch.Tensor]
-            For each ring-pipeline sensor class with at least one sensor on this entity, a tensor of shape
-            (B, [history,] entity_cache_size_for_class). Camera sensors are excluded; read them via ``camera.read()``.
+            For each vector sensor class with at least one sensor on this entity, a tensor of shape
+            (B, [history,] entity_cache_size_for_class).
         """
         return self._sim._sensor_manager.read_sensors(entity_idx=self._idx, envs_idx=envs_idx)
+
+    def read_cameras(self, envs_idx=None) -> dict:
+        """
+        Render and read every camera sensor attached to this entity, one entry per camera.
+
+        Entity-scoped companion to :meth:`read_sensors`; see :meth:`Scene.read_cameras`.
+
+        Returns
+        -------
+        dict[Sensor, CameraReturnType]
+            Mapping from each attached camera sensor to its rendered modalities.
+        """
+        return self._sim._sensor_manager.read_cameras(entity_idx=self._idx, envs_idx=envs_idx)
 
     # ------------------------------------------------------------------------------------
     # --------------------------------- naming methods -----------------------------------

--- a/genesis/engine/scene.py
+++ b/genesis/engine/scene.py
@@ -644,10 +644,11 @@ class Scene(RBC):
     @gs.assert_built
     def read_sensors(self, envs_idx=None) -> "dict[type[Sensor], torch.Tensor]":
         """
-        Read every sensor in the scene as a tensor per sensor class.
+        Read every **vector** sensor in the scene as a tensor per sensor class.
 
-        Always returns a fresh tensor independent of the internal sensor storage; the caller is free to mutate the
-        result.
+        This is the batched reader for vector-shaped sensors (IMU, contact, raycaster, ...). Camera sensors are not
+        included - read them via ``camera.read()`` or all at once via :meth:`read_cameras`. Always returns a fresh
+        tensor independent of the internal sensor storage; the caller is free to mutate the result.
 
         Parameters
         ----------
@@ -657,11 +658,29 @@ class Scene(RBC):
         Returns
         -------
         dict[Type[Sensor], torch.Tensor]
-            For each ring-pipeline sensor class present in the scene, a tensor of shape (B, [history,] class_cache_size).
-            Camera sensors are excluded (their multi-modality output has no single-tensor representation); read them via
-            ``camera.read()``.
+            For each vector sensor class present in the scene, a tensor of shape (B, [history,] class_cache_size).
         """
         return self._sim._sensor_manager.read_sensors(entity_idx=None, envs_idx=envs_idx)
+
+    def read_cameras(self, envs_idx=None) -> dict:
+        """
+        Render and read every camera sensor in the scene, one entry per camera.
+
+        The companion to :meth:`read_sensors` for image sensors: each camera is rendered and read individually, so
+        the result maps each camera sensor to its ``CameraReturnType`` (``.rgb`` / ``.depth`` / ``.segmentation`` /
+        ``.normal``). Rendering happens on call, so the cost is only paid when explicitly requested.
+
+        Parameters
+        ----------
+        envs_idx : array-like | int | slice | None
+            Environment selection passed through to each ``camera.read()``.
+
+        Returns
+        -------
+        dict[Sensor, CameraReturnType]
+            Mapping from each camera sensor to its rendered modalities.
+        """
+        return self._sim._sensor_manager.read_cameras(entity_idx=None, envs_idx=envs_idx)
 
     @gs.assert_unbuilt
     def start_recording(self, data_func: Callable, rec_options: "RecorderOptions") -> "Recorder":

--- a/genesis/engine/scene.py
+++ b/genesis/engine/scene.py
@@ -657,7 +657,9 @@ class Scene(RBC):
         Returns
         -------
         dict[Type[Sensor], torch.Tensor]
-            For each sensor class present in the scene, a tensor of shape (B, [history,] class_cache_size).
+            For each ring-pipeline sensor class present in the scene, a tensor of shape (B, [history,] class_cache_size).
+            Camera sensors are excluded (their multi-modality output has no single-tensor representation); read them via
+            ``camera.read()``.
         """
         return self._sim._sensor_manager.read_sensors(entity_idx=None, envs_idx=envs_idx)
 

--- a/genesis/engine/sensors/base_sensor.py
+++ b/genesis/engine/sensors/base_sensor.py
@@ -186,6 +186,11 @@ class Sensor(RBC, Generic[OptionsT, SharedSensorContextT, SharedSensorMetadataT,
     # Subclasses whose `_update_shared_cache` bypasses the rings (e.g. cameras handling rendering lazily) explicitly set
     # this to ``False``.
     uses_ring_pipeline: ClassVar[bool] = True
+    # Whether instances of this class use the manager's single-dtype per-class cache (and thus appear in
+    # `scene.read_sensors()`). Sensors that own their own storage and are read only via `sensor.read()` — currently the
+    # camera sensors, which hold multi-dtype image buffers — set this to ``False`` so the manager skips cache-size
+    # accounting for them and excludes them from `read_sensors()`.
+    uses_manager_cache: ClassVar[bool] = True
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)

--- a/genesis/engine/sensors/base_sensor.py
+++ b/genesis/engine/sensors/base_sensor.py
@@ -39,6 +39,51 @@ def _to_tuple(*values: NumArrayType, length_per_value: int = 3) -> tuple[Numeric
     return full_tuple
 
 
+def _normalize_field_dtypes(spec, n_fields: int, who: str) -> tuple[torch.dtype, ...]:
+    """
+    Normalize a ``_get_cache_dtype`` / ``_get_intermediate_dtype`` return value to one dtype per field.
+
+    A single ``torch.dtype`` broadcasts to every field (the common single-dtype case). A tuple must align 1:1 with the
+    fields of ``_get_return_format`` / ``_get_intermediate_format`` - one dtype per field, in field order.
+    """
+    if isinstance(spec, torch.dtype):
+        return (spec,) * n_fields
+    dtypes = tuple(spec)
+    if len(dtypes) != n_fields:
+        raise TypeError(f"{who} returned {len(dtypes)} dtypes for {n_fields} fields; must be one dtype per field.")
+    if not all(isinstance(dt, torch.dtype) for dt in dtypes):
+        raise TypeError(f"{who} must return a torch.dtype or a tuple of torch.dtype; got {dtypes}.")
+    return dtypes
+
+
+def _group_fields_by_dtype(format_spec, dtype_spec, who: str):
+    """
+    Partition a sensor's fields into per-dtype column groups.
+
+    ``format_spec`` is a ``_get_*_format`` value (a single ``(N,)`` shape or a tuple-of-shapes). ``dtype_spec`` is the
+    matching ``_get_*_dtype`` value (single dtype, or one per field). Fields sharing a dtype are laid out contiguously
+    within that dtype's column block; each field records its slice within its own dtype block, so a multi-dtype sensor
+    (e.g. a camera: uint8 rgb / float32 depth / int32 seg) contributes a contiguous run to each dtype buffer.
+
+    Returns ``(field_shapes, field_dtypes, size_by_dtype, field_slice_in_dtype)``:
+    - ``field_shapes``: per-field intrinsic shape tuple.
+    - ``field_dtypes``: per-field dtype.
+    - ``size_by_dtype``: dict[dtype, int] - total columns this sensor contributes to each dtype.
+    - ``field_slice_in_dtype``: per-field ``slice`` giving the field's offset within its dtype block.
+    """
+    shapes = (format_spec,) if isinstance(format_spec[0], int) else format_spec
+    shapes = tuple((s,) if isinstance(s, int) else tuple(s) for s in shapes)
+    dtypes = _normalize_field_dtypes(dtype_spec, len(shapes), who)
+    size_by_dtype: dict[torch.dtype, int] = {}
+    field_slice_in_dtype: list[slice] = []
+    for shape, dt in zip(shapes, dtypes):
+        data_size = int(np.prod(shape))
+        off = size_by_dtype.get(dt, 0)
+        field_slice_in_dtype.append(slice(off, off + data_size))
+        size_by_dtype[dt] = off + data_size
+    return shapes, dtypes, size_by_dtype, field_slice_in_dtype
+
+
 # Note: dataclass is used as opposed to pydantic.BaseModel since torch.Tensors are not supported by default
 @dataclass
 class SharedSensorMetadata:
@@ -181,16 +226,13 @@ class Sensor(RBC, Generic[OptionsT, SharedSensorContextT, SharedSensorMetadataT,
     # Cross-type shared context class declared as the second ``Sensor[...]`` parameter; ``NoneType`` (declared as
     # ``None``) means this sensor type consumes no shared context.
     _shared_context_cls: ClassVar[type] = type(None)
-    # Whether instances of this class participate in the ring-based per-step pipeline (delay sampling, transform
-    # recurrence, history snapshots). Drives allocation of the GT + measured timeline rings in `SensorManager.build`.
-    # Subclasses whose `_update_shared_cache` bypasses the rings (e.g. cameras handling rendering lazily) explicitly set
-    # this to ``False``.
+    # Whether instances of this class use the ``_apply_transform`` recurrence timeline rings (post-transform,
+    # pre-hardware-imperfection snapshots read by stateful filters). Drives allocation of the GT + measured timeline
+    # rings in `SensorManager.build`. Sensors that compute their output directly rather than via a stateful transform
+    # (e.g. cameras, which render on demand) set this to ``False``: they still get delay / jitter / history through the
+    # per-class return-space ring, but allocate no dead timeline rings. ``scene.read_sensors()`` — the eager per-step
+    # batched aggregate — likewise covers only ring-pipeline sensors; lazily-rendered ones are read via `sensor.read()`.
     uses_ring_pipeline: ClassVar[bool] = True
-    # Whether instances of this class use the manager's single-dtype per-class cache (and thus appear in
-    # `scene.read_sensors()`). Sensors that own their own storage and are read only via `sensor.read()` — currently the
-    # camera sensors, which hold multi-dtype image buffers — set this to ``False`` so the manager skips cache-size
-    # accounting for them and excludes them from `read_sensors()`.
-    uses_manager_cache: ClassVar[bool] = True
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
@@ -249,49 +291,50 @@ class Sensor(RBC, Generic[OptionsT, SharedSensorContextT, SharedSensorMetadataT,
         self._shared_metadata: SharedSensorMetadataT = shared_metadata
         self._is_built = False
 
-        # Classes that opt out of the ring pipeline (e.g. cameras handling rendering lazily on read) cannot honor delay
-        # / jitter / history because those features depend on the per-class return-space ring. Reject the inputs at
-        # construction so the user picks a different sensor or drops the option rather than silently getting no-ops.
-        if not self.uses_ring_pipeline:
-            if options.delay > 0.0:
-                gs.raise_exception(f"{type(self).__name__} does not support `delay`; got delay={options.delay}.")
-            if options.jitter > 0.0:
-                gs.raise_exception(f"{type(self).__name__} does not support `jitter`; got jitter={options.jitter}.")
-            if options.history_length > 0:
-                gs.raise_exception(
-                    f"{type(self).__name__} does not support `history_length`; got "
-                    f"history_length={options.history_length}."
-                )
-
         self._dt = self._manager._sim.dt
         self._delay_ts = round(self._options.delay / self._dt)
 
-        self._cache_slices: list[slice] = []
-        return_format = self._get_return_format()
-        assert len(return_format) > 0
-        intrinsic_shapes: tuple[tuple[int, ...], ...] = (
-            (return_format,) if isinstance(return_format[0], int) else return_format
+        # Per-field grouping by dtype. `_get_return_format` is already multi-field (e.g. IMU's (lin_acc, ang_vel, mag));
+        # `_get_cache_dtype` may now return one dtype per field so a single sensor can span several dtype buffers (a
+        # camera emits uint8 rgb / float32 depth+normal / int32 segmentation). Single-dtype sensors keep exactly their
+        # old single-block layout (`_normalize_field_dtypes` broadcasts the lone dtype to every field).
+        (
+            self._field_shapes,
+            self._field_dtypes,
+            self._return_size_by_dtype,
+            self._field_return_slice,
+        ) = _group_fields_by_dtype(self._get_return_format(), self._get_cache_dtype(), "_get_cache_dtype")
+        assert len(self._field_shapes) > 0
+        (
+            self._intermediate_field_shapes,
+            self._intermediate_field_dtypes,
+            self._intermediate_size_by_dtype,
+            self._field_intermediate_slice,
+        ) = _group_fields_by_dtype(
+            self._get_intermediate_format(), self._get_intermediate_dtype(), "_get_intermediate_dtype"
         )
 
         history_length = self._options.history_length
-        self._cache_size = 0
-        self._read_flat_slices: list[slice] = []
-        read_off = 0
-        for shape in intrinsic_shapes:
-            data_size = np.prod(shape)
-            self._cache_slices.append(slice(self._cache_size, self._cache_size + data_size))
-            self._cache_size += data_size
-
-            span = data_size * history_length if history_length > 0 else data_size
-            self._read_flat_slices.append(slice(read_off, read_off + span))
-            read_off += span
-
         if history_length > 0:
-            self._return_shapes = tuple((history_length, *s) for s in intrinsic_shapes)
+            self._return_shapes = tuple((history_length, *s) for s in self._field_shapes)
         else:
-            self._return_shapes = intrinsic_shapes
+            self._return_shapes = self._field_shapes
 
-        self._cache_idx: int = -1  # initialized by SensorManager during build
+        # Start column of this sensor within each dtype's per-class cache block; filled by SensorManager.build().
+        # `_cache_idx_by_dtype` indexes the intermediate caches; `_return_idx_by_dtype` indexes the return caches (they
+        # coincide unless `_post_process` changes dtype, e.g. ContactSensor's float intermediate -> bool return).
+        self._cache_idx_by_dtype: dict[torch.dtype, int] = {}
+        self._return_idx_by_dtype: dict[torch.dtype, int] = {}
+
+    @property
+    def _cache_size(self) -> int:
+        """
+        Total intermediate columns this sensor contributes across all its dtype buffers.
+
+        For a single-dtype sensor this equals the old ``prod``-summed cache size exactly, so single-dtype callers
+        (metadata field sizing, per-sensor kernel offsets in temperature/raycaster/probe) are unaffected.
+        """
+        return sum(self._intermediate_size_by_dtype.values())
 
     # =============================== methods to implement ===============================
 
@@ -339,17 +382,18 @@ class Sensor(RBC, Generic[OptionsT, SharedSensorContextT, SharedSensorMetadataT,
         """
         raise NotImplementedError(f"{type(self).__name__} has not implemented `_get_return_format()`.")
 
-    @classmethod
-    def _get_cache_dtype(cls) -> torch.dtype:
+    def _get_cache_dtype(self):
         """
-        Dtype of what ``read()`` returns; classmethod because the dtype is class-uniform across all instances.
+        Dtype(s) of what ``read()`` returns. Return a single ``torch.dtype`` (the common case - broadcast to every
+        field), or a tuple of dtypes aligned 1:1 with the fields of ``_get_return_format`` for a multi-dtype sensor
+        (e.g. a camera: ``(torch.uint8, torch.float32, torch.int32, torch.float32)`` for rgb/depth/seg/normal).
 
-        The manager allocates one per-dtype intermediate cache buffer and uses a per-class slice within it; if instances
-        of the same class returned different dtypes, the per-class slice would no longer be a single contiguous range,
-        breaking the per-class batched ``_update_shared_cache`` and ``_apply_transform`` contract. Dtype is therefore
-        class-uniform by design.
+        The manager allocates one intermediate cache buffer per dtype; a sensor's fields are grouped by dtype, and each
+        dtype group occupies its own contiguous per-class slice within that dtype's buffer. Instances of a class may
+        vary which fields/dtypes they enable (a camera's modality set is per-instance) as long as the field->dtype
+        mapping is consistent, which is why this is an instance method.
         """
-        raise NotImplementedError(f"{cls.__name__} has not implemented `_get_cache_dtype()`.")
+        raise NotImplementedError(f"{type(self).__name__} has not implemented `_get_cache_dtype()`.")
 
     def _get_intermediate_format(self) -> tuple[int | tuple[int, ...], ...]:
         """
@@ -360,43 +404,48 @@ class Sensor(RBC, Generic[OptionsT, SharedSensorContextT, SharedSensorMetadataT,
         """
         return self._get_return_format()
 
-    @classmethod
-    def _get_intermediate_dtype(cls) -> torch.dtype:
+    def _get_intermediate_dtype(self):
         """
-        Dtype of the pipeline-internal cache; defaults to ``_get_cache_dtype()``.
+        Dtype(s) of the pipeline-internal cache; defaults to ``_get_cache_dtype()``.
 
         Override together with ``_post_process`` when the projection changes dtype (e.g. ContactSensor's float
-        intermediate vs. bool return). Same class-uniform semantics as ``_get_cache_dtype``.
+        intermediate vs. bool return). Single dtype or per-field tuple, same semantics as ``_get_cache_dtype``.
         """
-        return cls._get_cache_dtype()
+        return self._get_cache_dtype()
 
     @classmethod
     def _update_shared_cache(
         cls,
         shared_context: SharedSensorContextT,
         shared_metadata: SharedSensorMetadataT,
-        current_ground_truth_data_T: torch.Tensor,
-        ground_truth_data_timeline: "TensorRingBuffer | None",
-        measured_data_timeline: "TensorRingBuffer | None",
-        intermediate_cache: torch.Tensor,
+        ground_truth_slices: dict,
+        ground_truth_data_timelines: dict,
+        measured_data_timelines: dict,
+        intermediates: dict,
     ):
         """
         Compute one step of sensor data into the shared caches up to the per-step working buffer.
 
-        Updates the shared ground-truth cache slice (shape ``(cols, B)``, C-contiguous rows), the GT timeline ring
-        (``ground_truth_data_timeline.at(0)`` is the current GT write slot, post-transform), the measured timeline ring
-        (``measured_data_timeline.at(0)`` is the current measured write slot, post-physics-imperfections /
-        post-transform / PRE-hardware-imperfections), and the per-dtype ``intermediate_cache`` (shape ``(B, cols)``, the
-        per-step measured working buffer in intermediate space: post-HW-imperfections, pre-``_post_process``,
-        pre-delay-sample). When the sensor opts out of the ring pipeline (e.g. Camera), both timeline rings are ``None``
-        and the implementation writes directly to ``intermediate_cache``. The manager handles ``_post_process``
-        projection, return-space ring writes, and delay sampling after this hook returns.
+        The four data arguments are dicts keyed by this class's intermediate dtype(s) - one entry per dtype the class
+        spans (a single entry for the common single-dtype sensor; several for a multi-dtype camera). For each dtype:
+        ``ground_truth_slices[dt]`` is the GT cache slice (shape ``(cols, B)``, C-contiguous rows);
+        ``ground_truth_data_timelines[dt]`` / ``measured_data_timelines[dt]`` are the paired timeline rings whose
+        ``.at(0)`` is the current write slot (post-transform, PRE-hardware-imperfections), or ``None`` when the dtype
+        has no ring pipeline; ``intermediates[dt]`` is the per-step measured working buffer (shape ``(B, cols)``,
+        post-HW-imperfections, pre-``_post_process``, pre-delay-sample). Sensors that opt out of the ring pipeline (e.g.
+        Camera) get ``None`` timelines and write their rendered data directly into ``intermediates[dt]`` (and, for GT,
+        ``ground_truth_slices[dt]``). The manager handles ``_post_process`` projection, return-space ring writes, and
+        delay sampling after this hook returns.
         """
         raise NotImplementedError(f"{cls.__name__} has not implemented `update_shared_cache()`.")
 
     @classmethod
     def _apply_delay(
-        cls, shared_metadata: SharedSensorMetadataT, return_ring: "TensorRingBuffer", return_cache: torch.Tensor
+        cls,
+        shared_metadata: SharedSensorMetadataT,
+        return_ring: "TensorRingBuffer",
+        return_cache: torch.Tensor,
+        sensor_layout: list[tuple[int, int]],
     ):
         """
         Sample stale slots of the measured return-space ring into the user-visible measured return cache.
@@ -407,9 +456,11 @@ class Sensor(RBC, Generic[OptionsT, SharedSensorContextT, SharedSensorMetadataT,
         is appropriate (e.g. linear interpolation between adjacent slots for a continuous-valued sensor whose return
         dtype is float).
 
-        ``return_ring`` is the per-class measured return-space ring (slot 0 = current step's post-everything value;
-        slots 1.. are previous steps in increasing age). ``return_cache`` is the per-class measured return cache to
-        populate; it is in return space (same shape and dtype as the ring).
+        ``return_ring`` / ``return_cache`` are the per-(class, return-dtype) measured ring and cache: a multi-dtype
+        sensor (e.g. a camera) is delay-sampled once per dtype it spans. ``sensor_layout`` is the ordered
+        ``(global_sensor_idx, size_in_this_dtype)`` list for the sensors contributing columns to THIS dtype's cache;
+        ``global_sensor_idx`` indexes the per-sensor ``delays_ts`` / ``jitter_ts`` columns (shared across dtypes), and
+        ``size_in_this_dtype`` is how many columns that sensor occupies in this dtype's return cache.
         """
         if not shared_metadata.has_any_delay and not shared_metadata.has_any_jitter:
             # Fast path: no per-sensor delay loop, just copy the most recent slot class-wide.
@@ -424,7 +475,7 @@ class Sensor(RBC, Generic[OptionsT, SharedSensorContextT, SharedSensorMetadataT,
             cur_jitter_ts = None
 
         tensor_start = 0
-        for sensor_idx, tensor_size in enumerate(shared_metadata.cache_sizes):
+        for sensor_idx, tensor_size in sensor_layout:
             cur_delay_ts = shared_metadata.delays_ts[:, sensor_idx]
             if cur_jitter_ts is not None:
                 # Probabilistic rounding of the continuous-time delay onto integer ring slots: with `jitter < dt` (one
@@ -513,20 +564,20 @@ class Sensor(RBC, Generic[OptionsT, SharedSensorContextT, SharedSensorMetadataT,
 
     # =============================== private shared methods ===============================
 
-    def _get_formatted_data(self, tensor: torch.Tensor, envs_idx=None) -> torch.Tensor:
+    def _get_formatted_data(self, fields: list[torch.Tensor], envs_idx=None) -> torch.Tensor:
         """
         Returns tensor(s) matching the return format.
 
-        Note that this method does not clone the data tensor, it should have been cloned by the caller.
+        ``fields`` is the per-field list produced by ``SensorManager.get_cloned_from_cache`` - one ``(B, span)`` tensor
+        per return field (``span`` folds in the history dimension when history is enabled). Each is reshaped to its
+        return shape; a single-field sensor returns the bare tensor, a multi-field sensor its NamedTuple. Note that this
+        method does not clone the data, it should have been cloned by the caller.
         """
         envs_idx = self._sanitize_envs_idx(envs_idx)
 
         return_values = []
-        tensor_chunk = tensor[envs_idx].reshape((len(envs_idx), -1))
-
-        for i, shape in enumerate(self._return_shapes):
-            sl = self._read_flat_slices[i]
-            field_data = tensor_chunk[..., sl].reshape((len(envs_idx), *shape))
+        for shape, field_tensor in zip(self._return_shapes, fields):
+            field_data = field_tensor[envs_idx].reshape((len(envs_idx), *shape))
             if self._manager._sim.n_envs == 0:
                 field_data = field_data[0]
             return_values.append(field_data)
@@ -806,11 +857,18 @@ class SimpleSensor(Sensor[OptionsT, SharedSensorContextT, SharedSensorMetadataT,
         cls,
         shared_context: SharedSensorContextT,
         shared_metadata: SharedSensorMetadata,
-        current_ground_truth_data_T: torch.Tensor,
-        ground_truth_data_timeline: "TensorRingBuffer | None",
-        measured_data_timeline: "TensorRingBuffer | None",
-        intermediate_cache: torch.Tensor,
+        ground_truth_slices: dict,
+        ground_truth_data_timelines: dict,
+        measured_data_timelines: dict,
+        intermediates: dict,
     ):
+        # SimpleSensor is single-dtype, so each per-dtype dict from the manager has exactly one entry. Unpack the sole
+        # intermediate-dtype buffers back to the scalar tensors the pipeline hooks operate on.
+        (current_ground_truth_data_T,) = ground_truth_slices.values()
+        (ground_truth_data_timeline,) = ground_truth_data_timelines.values()
+        (measured_data_timeline,) = measured_data_timelines.values()
+        (intermediate_cache,) = intermediates.values()
+
         # Both branches share the same raw signal. The GT and measured timeline rings (paired, same size, shared
         # rotation idx) store post-transform, PRE-hardware-imperfections data; `_apply_transform` reads previous ring
         # slots cleanly and hardware imperfections never write back to the ring, so transform recurrence stays clean.

--- a/genesis/engine/sensors/camera.py
+++ b/genesis/engine/sensors/camera.py
@@ -269,7 +269,7 @@ class BaseCameraSensor(KinematicSensorMixin, Sensor[OptionsT, None, SharedSensor
         if not sensors:
             return
         manager = sensors[0]._manager
-        if cls not in manager._measured_return_timeline_ring:
+        if not manager.class_has_return_ring(cls):
             return
         shared_metadata.last_render_timestep = -1
         for sensor in sensors:
@@ -336,74 +336,85 @@ class BaseCameraSensor(KinematicSensorMixin, Sensor[OptionsT, None, SharedSensor
 
     # ========================== Capability delegation to the owned vis.Camera ==========================
 
+    def _require_camera(self) -> "Camera":
+        # The owned vis.Camera is created eagerly at build for standalone/headless rendering, but lazily on the first
+        # render when sharing a live viewer's rasterizer. Give a clear message instead of a NoneType error if pose /
+        # intrinsics are accessed before that first render on the viewer-shared path.
+        if self._camera is None:
+            gs.raise_exception(
+                "Camera not built yet: its underlying vis.Camera is created on the first render when sharing a live "
+                "viewer. Step the scene or call `read()` once before accessing camera pose / intrinsics."
+            )
+        return self._camera
+
     @property
     def camera(self) -> "Camera":
         """The underlying `vis.Camera` this sensor renders through (pose, intrinsics, extrinsics, ...)."""
-        return self._camera
+        return self._require_camera()
 
     @gs.assert_built
     def set_pose(self, transform=None, pos=None, lookat=None, up=None, envs_idx=None):
         """Set the camera pose. Delegates to `vis.Camera.set_pose` (per-env when batched)."""
-        self._camera.set_pose(transform=transform, pos=pos, lookat=lookat, up=up, envs_idx=envs_idx)
+        self._require_camera().set_pose(transform=transform, pos=pos, lookat=lookat, up=up, envs_idx=envs_idx)
         # Invalidate the lazy-render cache so the next read re-renders from the new pose within the same step.
         self._stale = True
 
     @gs.assert_built
     def get_pos(self, envs_idx=None):
-        return self._camera.get_pos(envs_idx)
+        return self._require_camera().get_pos(envs_idx)
 
     @gs.assert_built
     def get_quat(self, envs_idx=None):
-        return self._camera.get_quat(envs_idx)
+        return self._require_camera().get_quat(envs_idx)
 
     @gs.assert_built
     def get_transform(self, envs_idx=None):
-        return self._camera.get_transform(envs_idx)
+        return self._require_camera().get_transform(envs_idx)
 
     @gs.assert_built
     def get_lookat(self, envs_idx=None):
-        return self._camera.get_lookat(envs_idx)
+        return self._require_camera().get_lookat(envs_idx)
 
     @gs.assert_built
     def get_up(self, envs_idx=None):
-        return self._camera.get_up(envs_idx)
+        return self._require_camera().get_up(envs_idx)
 
     @property
     def intrinsics(self):
         """The camera intrinsics matrix `K`."""
-        return self._camera.intrinsics
+        return self._require_camera().intrinsics
 
     @property
     def extrinsics(self):
         """The camera extrinsics (world-to-camera) matrix."""
-        return self._camera.extrinsics
+        return self._require_camera().extrinsics
 
     @property
     def projection_matrix(self):
         """The OpenGL projection matrix."""
-        return self._camera.projection_matrix
+        return self._require_camera().projection_matrix
 
     @property
     def f(self):
         """The focal length in pixels."""
-        return self._camera.f
+        return self._require_camera().f
 
     @property
     def cx(self):
-        return self._camera.cx
+        return self._require_camera().cx
 
     @property
     def cy(self):
-        return self._camera.cy
+        return self._require_camera().cy
 
     def distance_center_to_plane(self, center_dis):
         """Convert Euclidean center distance (range along the ray) to planar Z depth."""
-        return self._camera.distance_center_to_plane(center_dis)
+        return self._require_camera().distance_center_to_plane(center_dis)
 
     @gs.assert_built
     def render_pointcloud(self, world_frame=True):
         """Render a partial point cloud from the camera view (depth-deprojected)."""
-        return self._camera.render_pointcloud(world_frame=world_frame)
+        return self._require_camera().render_pointcloud(world_frame=world_frame)
 
     # ========================== Shared read() ==========================
 
@@ -434,7 +445,7 @@ class BaseCameraSensor(KinematicSensorMixin, Sensor[OptionsT, None, SharedSensor
         # Eager (delay/history) cameras are rendered every step into the return-space ring by `_update_shared_cache`;
         # `read()` then just samples the ring and must NOT re-render. Lazy (no-ring) cameras render on read into the
         # aliased cache.
-        return type(self) in self._manager._measured_return_timeline_ring
+        return self._manager.class_has_return_ring(type(self))
 
     @gs.assert_built
     def read(self, envs_idx=None) -> CameraReturnType:

--- a/genesis/engine/sensors/camera.py
+++ b/genesis/engine/sensors/camera.py
@@ -85,38 +85,11 @@ def _enabled_modalities(options) -> tuple[str, ...]:
     return tuple(name for name in _CAMERA_MODALITIES if getattr(options, f"render_{name}"))
 
 
-def _allocate_image_cache(options, B: int, w: int, h: int) -> Dict[str, torch.Tensor]:
-    """Allocate one zero buffer per enabled modality, keyed by modality name."""
-    return {
-        name: torch.zeros(_modality_shape(name, B, w, h), dtype=_modality_dtype(name), device=gs.device)
-        for name in _enabled_modalities(options)
-    }
-
-
 def _to_cache_tensor(arr, dtype: torch.dtype) -> torch.Tensor:
     """Convert a rendered array (numpy, possibly with negative strides, or torch/CUDA) to a contiguous typed tensor."""
     if isinstance(arr, torch.Tensor):
         return arr.to(dtype=dtype, device=gs.device).contiguous()
     return torch.from_numpy(np.ascontiguousarray(arr)).to(dtype=dtype, device=gs.device)
-
-
-def _store_render_into_cache(cache: Dict[str, torch.Tensor], render_tuple, dst=slice(None)):
-    """
-    Scatter a backend render tuple `(rgb, depth, segmentation, normal)` into the per-modality cache at index `dst`.
-
-    Only modalities present in `cache` and non-None in `render_tuple` are written. A single-env render (missing the
-    batch dim) is unsqueezed to match the cache's leading batch dimension.
-    """
-    for name, arr in zip(_CAMERA_MODALITIES, render_tuple):
-        if name not in cache or arr is None:
-            continue
-        buf = cache[name]
-        target = buf[dst]
-        t = _to_cache_tensor(arr, buf.dtype)
-        if t.ndim == target.ndim - 1:
-            # Single-environment render missing the batch dim; add it to match the destination slice.
-            t = t.unsqueeze(0)
-        buf[dst] = t
 
 
 class MinimalVisualizerWrapper:
@@ -244,9 +217,6 @@ class RasterizerCameraSharedMetadata(KinematicSensorMetadataMixin, SharedSensorM
     lights: Optional[List[Dict[str, Any]]] = None
     # List of RasterizerCameraSensor instances
     sensors: Optional[List["RasterizerCameraSensor"]] = None
-    # {sensor_idx: {modality_name: torch.Tensor}}; rgb (B,H,W,3) uint8, depth (B,H,W) f32, segmentation (B,H,W) i32,
-    # normal (B,H,W,3) f32. Only enabled modalities are allocated (see `_allocate_image_cache`).
-    image_cache: Optional[Dict[int, Dict[str, "torch.Tensor"]]] = None
     # Track when rasterizer cameras were last updated
     last_render_timestep: int = -1
 
@@ -260,7 +230,6 @@ class RasterizerCameraSharedMetadata(KinematicSensorMetadataMixin, SharedSensorM
             self.context.destroy()
             self.context = None
         self.lights = None
-        self.image_cache = None
         self.sensors = None
 
 
@@ -274,9 +243,6 @@ class RaytracerCameraSharedMetadata(KinematicSensorMetadataMixin, SharedSensorMe
     lights: Optional[List[Any]] = None
     # List of RaytracerCameraSensor instances
     sensors: Optional[List["RaytracerCameraSensor"]] = None
-    # {sensor_idx: {modality_name: torch.Tensor}}; rgb (B,H,W,3) uint8, depth (B,H,W) f32, segmentation (B,H,W) i32,
-    # normal (B,H,W,3) f32. Only enabled modalities are allocated (see `_allocate_image_cache`).
-    image_cache: Optional[Dict[int, Dict[str, "torch.Tensor"]]] = None
     # Track when raytracer cameras were last updated
     last_render_timestep: int = -1
 
@@ -285,7 +251,6 @@ class RaytracerCameraSharedMetadata(KinematicSensorMetadataMixin, SharedSensorMe
 
         self.renderer = None
         self.sensors = None
-        self.image_cache = None
 
 
 @dataclass
@@ -298,9 +263,6 @@ class BatchRendererCameraSharedMetadata(KinematicSensorMetadataMixin, SharedSens
     lights: Optional[Any] = None
     # List of BatchRendererCameraSensor instances
     sensors: Optional[List["BatchRendererCameraSensor"]] = None
-    # {sensor_idx: {modality_name: torch.Tensor}}; rgb (B,H,W,3) uint8, depth (B,H,W) f32, segmentation (B,H,W) i32,
-    # normal (B,H,W,3) f32. Only enabled modalities are allocated (see `_allocate_image_cache`).
-    image_cache: Optional[Dict[int, Dict[str, "torch.Tensor"]]] = None
     # Track when batch was last rendered
     last_render_timestep: int = -1
     # MinimalVisualizerWrapper instance
@@ -311,7 +273,6 @@ class BatchRendererCameraSharedMetadata(KinematicSensorMetadataMixin, SharedSens
 
         self.renderer = None
         self.sensors = None
-        self.image_cache = None
         self.visualizer_wrapper = None
 
 
@@ -320,20 +281,24 @@ class BatchRendererCameraSharedMetadata(KinematicSensorMetadataMixin, SharedSens
 
 class BaseCameraSensor(KinematicSensorMixin, Sensor[OptionsT, None, SharedSensorMetadata, CameraReturnType]):
     """
-    Base class for camera sensors that render RGB images into an internal image_cache.
+    Base class for camera sensors that render multi-modality images into the shared sensor cache.
 
-    This class centralizes:
-    - Attachment handling via KinematicSensorMixin
-    - The _stale flag used for auto-render-on-read
-    - Common Sensor cache integration (shape/dtype)
-    - Shared read() method returning torch tensors
+    Cameras are first-class sensors: their enabled modalities (rgb uint8 / depth float32 / segmentation int32 / normal
+    float32) are declared per-instance via `_get_return_format` / `_get_cache_dtype`, and the manager lays each out in
+    its own dtype's per-class cache. They therefore flow through the same delay / jitter / history / return machinery as
+    every other sensor.
+
+    `uses_ring_pipeline = False` means cameras don't use the `_apply_transform` recurrence timeline rings (they render
+    directly, with no stateful transform), so no dead timeline rings are allocated - but they still get delay / jitter /
+    history through the per-class return-space ring. Rendering is hybrid: lazy (on `read()`) when no delay/history is
+    requested (the manager's no-ring alias fast path), eager (every step, inside `_update_shared_cache`) when a
+    delay/history ring exists, since those inherently require capturing every past frame.
+
+    This class centralizes attachment handling (via KinematicSensorMixin), the `_stale` render-dedup flag, and the
+    render->cache scatter; subclasses implement the backend-specific `_render_current_state`.
     """
 
     uses_ring_pipeline: ClassVar[bool] = False
-    # Cameras store multi-dtype images (uint8 rgb / float32 depth+normal / int32 seg) in their own `image_cache` and are
-    # read via `sensor.read()`. The manager's per-class cache is single-dtype, so cameras opt out of it entirely; this
-    # also excludes them from `scene.read_sensors()`.
-    uses_manager_cache: ClassVar[bool] = False
 
     def __init__(
         self,
@@ -343,36 +308,79 @@ class BaseCameraSensor(KinematicSensorMixin, Sensor[OptionsT, None, SharedSensor
         shared_metadata,
         manager: "SensorManager",
     ):
-        # `uses_ring_pipeline = False` triggers the generic delay / jitter / history rejection in `Sensor.__init__`.
         super().__init__(options, idx, shared_context, shared_metadata, manager)
+        self._enabled: tuple[str, ...] = _enabled_modalities(options)
         self._stale: bool = True
 
     # ========================== Cache Integration (shared) ==========================
 
-    # NOTE: `_get_return_format`/`_get_cache_dtype` are vestigial for cameras. Because `uses_manager_cache = False`, the
-    # manager skips cache-size accounting for camera classes, so these values are not used to size any buffer; camera
-    # output lives in the multi-dtype `image_cache` instead. They are kept only to satisfy the `Sensor` contract.
     def _get_return_format(self) -> tuple[tuple[int, ...], ...]:
+        # One shape per enabled modality, batch dim dropped (the manager prepends B). Order follows `_CAMERA_MODALITIES`
+        # (the backends' render-tuple order), matching `_get_cache_dtype` field-for-field.
         w, h = self._options.res
-        return ((h, w, 3),)
+        return tuple(_modality_shape(name, 1, w, h)[1:] for name in _enabled_modalities(self._options))
 
-    @classmethod
-    def _get_cache_dtype(cls) -> torch.dtype:
-        return torch.uint8
+    def _get_cache_dtype(self):
+        # Per-modality dtype tuple aligned 1:1 with `_get_return_format`: uint8 rgb / float32 depth+normal / int32 seg.
+        return tuple(_modality_dtype(name) for name in _enabled_modalities(self._options))
 
     @classmethod
     def _update_shared_cache(
         cls,
         shared_context: None,
         shared_metadata: SharedSensorMetadata,
-        current_ground_truth_data_T: torch.Tensor,
-        ground_truth_data_timeline: "TensorRingBuffer | None",
-        measured_data_timeline: "TensorRingBuffer | None",
-        intermediate_cache: torch.Tensor,
+        ground_truth_slices: dict,
+        ground_truth_data_timelines: dict,
+        measured_data_timelines: dict,
+        intermediates: dict,
     ):
-        # No per-step cache update for cameras (handled lazily on read()). `BaseCameraSensor` declares
-        # `uses_ring_pipeline = False`, so the manager passes both timeline rings as ``None`` here.
-        pass
+        # Hybrid render timing. Render eagerly (every step) only when this class has a delay/history return ring, which
+        # inherently needs every past frame captured; the render scatters into the manager cache slices, which the ring
+        # then snapshots below (in `SensorManager.step`). With no ring, this is a no-op and rendering happens lazily on
+        # `read()` into the aliased cache - preserving the "don't render if nobody reads" optimization.
+        #
+        # Force staleness before rendering rather than reusing the `scene.t`-based dedup: this hook runs during
+        # `sim.step()` while `scene.t` is still pre-increment, and an interleaved `read()` at the post-increment `t`
+        # would otherwise make the dedup skip this step's render and snapshot a stale frame. `_stale` is still used to
+        # dedup the batch renderer's single all-camera pass within this loop.
+        sensors = shared_metadata.sensors
+        if not sensors:
+            return
+        manager = sensors[0]._manager
+        if cls not in manager._measured_return_timeline_ring:
+            return
+        shared_metadata.last_render_timestep = -1
+        for sensor in sensors:
+            sensor._stale = True
+        for sensor in sensors:
+            sensor._ensure_rendered_for_current_state()
+
+    def _scatter_render_into_manager_cache(self, render_tuple):
+        """
+        Scatter a backend render tuple `(rgb, depth, segmentation, normal)` into this sensor's columns of the manager's
+        per-dtype intermediate + ground-truth caches. Cameras have no measured/GT distinction, so both receive the same
+        rendered data. Only enabled, non-None modalities are written.
+        """
+        manager = self._manager
+        batch = max(manager._sim.n_envs, 1)
+        w, h = self._options.res
+        by_name = dict(zip(_CAMERA_MODALITIES, render_tuple))
+        for i, name in enumerate(self._enabled):
+            arr = by_name.get(name)
+            if arr is None:
+                continue
+            dtype = self._field_dtypes[i]
+            field_slice = self._field_intermediate_slice[i]
+            start = self._cache_idx_by_dtype[dtype]
+            cols = slice(start + field_slice.start, start + field_slice.stop)
+            tensor = _to_cache_tensor(arr, dtype)
+            if tensor.ndim == len(_modality_shape(name, batch, w, h)) - 1:
+                # Single-environment render missing the batch dim; add it to match the (B, ...) cache layout.
+                tensor = tensor.unsqueeze(0)
+            flat = tensor.reshape(batch, -1)
+            manager._intermediate_cache[dtype][:, cols] = flat
+            # GT cache is stored transposed (cols, B); mirror the same data since cameras have no GT/measured split.
+            manager._ground_truth_intermediate_cache[dtype][cols, :] = flat.T
 
     def _draw_debug(self, context: "RasterizerContext"):
         """No debug drawing for cameras."""
@@ -418,10 +426,6 @@ class BaseCameraSensor(KinematicSensorMixin, Sensor[OptionsT, None, SharedSensor
 
     # ========================== Shared read() ==========================
 
-    def _get_image_cache_entry(self):
-        """Return this sensor's entry in the shared image cache."""
-        return self._shared_metadata.image_cache[self._idx]
-
     def _ensure_rendered_for_current_state(self):
         """Ensure this camera has an up-to-date render before reading.
         Base handles staleness and timestamps; subclasses implement _render_current_state().
@@ -449,52 +453,52 @@ class BaseCameraSensor(KinematicSensorMixin, Sensor[OptionsT, None, SharedSensor
         # Mark as fresh
         self._stale = False
 
-    def _sanitize_envs_idx(self, envs_idx):
-        """Sanitize envs_idx to valid indices."""
-        if envs_idx is None:
-            return None
-        if isinstance(envs_idx, (int, np.integer)):
-            return envs_idx
-        return np.asarray(envs_idx)
+    def _is_eager(self) -> bool:
+        # Eager (delay/history) cameras are rendered every step into the return-space ring by `_update_shared_cache`;
+        # `read()` then just samples the ring and must NOT re-render. Lazy (no-ring) cameras render on read into the
+        # aliased cache.
+        return type(self) in self._manager._measured_return_timeline_ring
 
     @gs.assert_built
     def read(self, envs_idx=None) -> CameraReturnType:
-        """Render if needed, then read the cached image from the backend-specific cache."""
-        self._ensure_rendered_for_current_state()
-        cached_image = self._get_image_cache_entry()
-        return _camera_read_from_image_cache(self, cached_image, envs_idx, to_numpy=False)
+        """Read this camera's modalities from the shared sensor cache, rendering first on the lazy (no-ring) path."""
+        if not self._is_eager():
+            self._ensure_rendered_for_current_state()
+        return self._camera_format(self._manager.get_cloned_from_cache(self), envs_idx)
 
+    @gs.assert_built
+    def read_ground_truth(self, envs_idx=None) -> CameraReturnType:
+        """Ground-truth read. Cameras have no measured/GT split, but the GT path is delay-free (undelayed frame)."""
+        if not self._is_eager():
+            self._ensure_rendered_for_current_state()
+        return self._camera_format(self._manager.get_cloned_from_cache(self, is_ground_truth=True), envs_idx)
 
-# ========================== Camera Sensor Helpers ==========================
-def _camera_read_from_image_cache(sensor, cached_image, envs_idx, *, to_numpy: bool) -> CameraReturnType:
-    """
-    Convert a per-modality image cache into a CameraReturnType with correct env handling.
+    @classmethod
+    def reset(cls, shared_metadata: SharedSensorMetadata, shared_ground_truth_cache, envs_idx):
+        # The shared cache backing cameras is zeroed on reset; invalidate render staleness so the next read re-renders
+        # instead of returning the zeroed cache (cameras own no separate storage anymore).
+        shared_metadata.last_render_timestep = -1
+        if shared_metadata.sensors is not None:
+            for sensor in shared_metadata.sensors:
+                sensor._stale = True
 
-    Parameters
-    ----------
-    sensor : any camera sensor with _manager and _return_data_class
-    cached_image : dict[str, torch.Tensor]
-        Per-modality image cache for this camera; each buffer is shaped (B, H, W[, 3]). Only enabled modalities are
-        present; the rest of the returned NamedTuple stays None.
-    envs_idx : None | int | sequence
-        Environment index/indices to select.
-    to_numpy : bool
-        If True, convert each returned buffer to numpy.
-    """
-    n_envs = sensor._manager._sim.n_envs
-
-    def select_envs(buf):
-        if envs_idx is None:
-            buf = buf[0] if n_envs == 0 else buf
-        elif isinstance(envs_idx, (int, np.integer)):
-            buf = buf[envs_idx]
-        else:
-            buf = buf[envs_idx]
-        if to_numpy and isinstance(buf, torch.Tensor):
-            buf = tensor_to_array(buf)
-        return buf
-
-    return sensor._return_data_class(**{name: select_envs(buf) for name, buf in cached_image.items()})
+    def _camera_format(self, fields, envs_idx=None) -> CameraReturnType:
+        """
+        Pack the per-field return blocks into a ``CameraReturnType`` keyed by enabled modality name (disabled
+        modalities stay ``None``), reshaping each to its image shape and applying env selection. Mirrors the historic
+        env-indexing semantics: ``envs_idx=None`` returns the batch (or the sole frame when ``n_envs==0``); an int index
+        selects and squeezes a single env; a sequence gathers those envs.
+        """
+        n_envs = self._manager._sim.n_envs
+        named: Dict[str, "torch.Tensor"] = {}
+        for name, shape, field in zip(self._enabled, self._return_shapes, fields):
+            buf = field.reshape((field.shape[0], *shape))  # (B, [H,] h, w[, 3])
+            if envs_idx is None:
+                buf = buf[0] if n_envs == 0 else buf
+            else:
+                buf = buf[envs_idx]
+            named[name] = buf
+        return CameraReturnType(**named)
 
 
 # ========================== Rasterizer Camera Sensor ==========================
@@ -536,7 +540,6 @@ class RasterizerCameraSensor(
         if self._shared_metadata.sensors is None:
             self._shared_metadata.sensors = []
             self._shared_metadata.lights = gs.List()
-            self._shared_metadata.image_cache = {}
 
             # If a viewer is active, reuse its windowed OpenGL context for both offscreen and onscreen rendering, rather
             # than creating a separate headless context which is fragile.
@@ -561,10 +564,6 @@ class RasterizerCameraSensor(
         # (visualizer isn't built yet at sensor.build() time)
         if self._shared_metadata.renderer.offscreen:
             self._ensure_camera_registered()
-
-        _B = max(self._manager._sim.n_envs, 1)
-        w, h = self._options.res
-        self._shared_metadata.image_cache[self._idx] = _allocate_image_cache(self._options, _B, w, h)
 
     def _ensure_camera_registered(self):
         """Register this camera with the renderer (no-op if already registered)."""
@@ -691,9 +690,8 @@ class RasterizerCameraSensor(
             node.mesh.primitives[0].poses = poses
             context.jit.update_buffer(node, "model", poses.transpose((0, 2, 1)))
 
-        # Scatter each requested modality into the per-modality cache. `_store_render_into_cache` handles negative
-        # strides, dtype casting, and adding the batch dim for single-environment renders.
-        _store_render_into_cache(self._shared_metadata.image_cache[self._idx], render_out)
+        # Scatter each requested modality into this sensor's columns of the shared manager cache.
+        self._scatter_render_into_manager_cache(render_out)
 
 
 # ========================== Raytracer Camera Sensor ==========================
@@ -746,7 +744,6 @@ class RaytracerCameraSensor(
         if self._shared_metadata.sensors is None:
             self._shared_metadata.sensors = []
             self._shared_metadata.lights = []
-            self._shared_metadata.image_cache = {}
             self._shared_metadata.renderer = renderer
 
         self._shared_metadata.sensors.append(self)
@@ -807,10 +804,6 @@ class RaytracerCameraSensor(
                 offset_T = pos_lookat_up_to_T(pos, lookat, up)
             self._camera_obj.attach(self._link, offset_T)
 
-        _B = max(n_envs, 1)
-        w, h = self._options.res
-        self._shared_metadata.image_cache[self._idx] = _allocate_image_cache(self._options, _B, w, h)
-
     @gs.assert_built
     def move_to_attach(self):
         # Bypass original implementation since it will be handled by visualizer
@@ -854,8 +847,9 @@ class RaytracerCameraSensor(
             antialiasing=False,
             force_render=True,
         )
-        # Raytracer camera sensors reject n_envs > 1, so the render is a single (non-batched) frame -> store into slot 0.
-        _store_render_into_cache(self._shared_metadata.image_cache[self._idx], render_out, dst=0)
+        # Raytracer camera sensors reject n_envs > 1, so the render is a single (non-batched) frame; the scatter helper
+        # adds the missing batch dim.
+        self._scatter_render_into_manager_cache(render_out)
 
 
 # ========================== Batch Renderer Camera Sensor ==========================
@@ -894,7 +888,6 @@ class BatchRendererCameraSensor(
         if self._shared_metadata.sensors is None:
             self._shared_metadata.sensors = []
             self._shared_metadata.lights = gs.List()
-            self._shared_metadata.image_cache = {}
             self._shared_metadata.last_render_timestep = -1
 
             all_sensors = self._manager._sensors_by_type[type(self)]
@@ -931,10 +924,6 @@ class BatchRendererCameraSensor(
             self._shared_metadata.visualizer_wrapper._cameras = [s._camera_obj for s in self._shared_metadata.sensors]
             self._shared_metadata.renderer.build()
 
-        _B = max(self._manager._sim.n_envs, 1)
-        w, h = self._options.res
-        self._shared_metadata.image_cache[self._idx] = _allocate_image_cache(self._options, _B, w, h)
-
     def _render_current_state(self):
         """Perform the actual render for the current state."""
         sensors = self._shared_metadata.sensors or [self]
@@ -969,7 +958,7 @@ class BatchRendererCameraSensor(
                 per_camera.append([arrs])
         for cam_i, sensor in enumerate(sensors):
             sensor_render = tuple(per_camera[mod_i][cam_i] for mod_i in range(len(_CAMERA_MODALITIES)))
-            _store_render_into_cache(sensor._shared_metadata.image_cache[sensor._idx], sensor_render)
+            sensor._scatter_render_into_manager_cache(sensor_render)
             sensor._stale = False
 
         self._shared_metadata.last_render_timestep = self._manager._sim.scene.t

--- a/genesis/engine/sensors/camera.py
+++ b/genesis/engine/sensors/camera.py
@@ -2,9 +2,8 @@
 Camera sensors for rendering: Rasterizer, Raytracer, and Batch Renderer.
 """
 
-import sys
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, NamedTuple, Optional, Type
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, NamedTuple, Optional
 
 import numpy as np
 import torch
@@ -18,16 +17,9 @@ from genesis.options.sensors import (
     SensorOptions,
 )
 from genesis.options.vis import VisOptions
-from genesis.utils.geom import (
-    T_to_quat,
-    T_to_trans,
-    pos_lookat_up_to_T,
-    trans_quat_to_T,
-    transform_by_quat,
-    transform_by_trans_quat,
-)
-from genesis.utils.misc import tensor_to_array
+from genesis.utils.geom import pos_lookat_up_to_T
 from genesis.vis.batch_renderer import BatchRenderer
+from genesis.vis.camera import Camera
 from genesis.vis.rasterizer import Rasterizer
 from genesis.vis.rasterizer_context import RasterizerContext
 
@@ -92,114 +84,35 @@ def _to_cache_tensor(arr, dtype: torch.dtype) -> torch.Tensor:
     return torch.from_numpy(np.ascontiguousarray(arr)).to(dtype=dtype, device=gs.device)
 
 
-class MinimalVisualizerWrapper:
+class StandaloneCameraBackend:
     """
-    Minimal visualizer wrapper for BatchRenderer camera sensors.
+    A minimal ``CameraBackendProvider`` for headless / sensor camera rendering, standing in for the interactive
+    ``Visualizer``.
 
-    BatchRenderer requires a visualizer-like object to provide camera information and context, but camera sensors don't
-    need the full visualizer functionality (viewer, UI, etc.). This wrapper provides just the minimal interface expected
-    by BatchRenderer while avoiding the overhead of creating a full visualizer instance.
+    A camera sensor owns a ``vis.Camera`` and builds/renders it against this provider, which exposes exactly the
+    closed set of members a ``Camera`` (and, for the batch path, ``BatchRenderer``) reaches for. It backs both the
+    standalone rasterizer path (``rasterizer`` set) and the batch path (``batch_renderer`` set); ``raytracer`` sensors
+    use the real ``Visualizer`` instead (they require one). It never creates a viewer/GUI.
     """
 
-    def __init__(self, scene, sensors, vis_options):
+    def __init__(self, scene, context, rasterizer=None, batch_renderer=None):
         self.scene = scene
-        self._cameras = []  # Will be populated with camera wrappers
-        self._sensors = sensors  # Keep reference to sensors
-
-        # Create a minimal rasterizer context for camera frustum visualization (required by BatchRenderer even though
-        # cameras don't render frustums)
-        self._context = RasterizerContext(vis_options)
-        self._context.build(scene)
-        self._context.reset()
-
-
-class BaseCameraWrapper:
-    """Base class for camera wrappers to reduce code duplication."""
-
-    def __init__(self, sensor):
-        self.sensor = sensor
-        self.uid = sensor._idx
-        self.res = sensor._options.res
-        self.fov = sensor._options.fov
-        self.near = sensor._options.near
-        self.far = sensor._options.far
-
-
-class RasterizerCameraWrapper(BaseCameraWrapper):
-    """Lightweight wrapper object used by the rasterizer backend."""
-
-    def __init__(self, sensor: "RasterizerCameraSensor"):
-        super().__init__(sensor)
-        self.aspect_ratio = self.res[0] / self.res[1]
-
-
-class BatchRendererCameraWrapper(BaseCameraWrapper):
-    """Wrapper object used by the batch renderer backend."""
-
-    def __init__(self, sensor: "BatchRendererCameraSensor"):
-        super().__init__(sensor)
-        self.idx = len(sensor._shared_metadata.sensors)  # Camera index in batch
-        self.model = sensor._options.model
-
-        # Initial pose
-        pos = torch.tensor(sensor._options.pos, dtype=gs.tc_float, device=gs.device)
-        lookat = torch.tensor(sensor._options.lookat, dtype=gs.tc_float, device=gs.device)
-        up = torch.tensor(sensor._options.up, dtype=gs.tc_float, device=gs.device)
-
-        # Store pos/lookat/up for later updates
-        self._pos = pos
-        self._lookat = lookat
-        self._up = up
-        self.transform = pos_lookat_up_to_T(pos, lookat, up)
-
-    def get_pos(self):
-        """Get camera position (for batch renderer)."""
-        n_envs = self.sensor._manager._sim.n_envs
-        if self._pos.ndim > 1 or n_envs == 0:
-            return self._pos
-        return self._pos[None].expand((n_envs, -1))
-
-    def get_quat(self):
-        """Get camera quaternion (for batch renderer)."""
-        quat = T_to_quat(self.transform)
-        n_envs = self.sensor._manager._sim.n_envs
-        if quat.ndim > 1 or n_envs == 0:
-            return quat
-        return quat[None].expand((n_envs, -1))
-
-    # Pinhole intrinsics, mirroring `genesis.vis.camera.Camera` (f/cx/cy), needed by `distance_center_to_plane`.
-    @property
-    def f(self):
-        return 0.5 * self.res[1] / np.tan(np.deg2rad(0.5 * self.fov))
+        self._context = context
+        self.rasterizer = rasterizer
+        self.raytracer = None
+        self.batch_renderer = batch_renderer
+        self.has_display = False
+        # `vis.Camera` instances enumerated by the batch renderer (mirrors `Visualizer._cameras`).
+        self._cameras: List["Camera"] = []
 
     @property
-    def cx(self):
-        return 0.5 * self.res[0]
+    def context(self):
+        return self._context
 
-    @property
-    def cy(self):
-        return 0.5 * self.res[1]
-
-    def distance_center_to_plane(self, center_dis):
-        """
-        Convert Euclidean center distance (range along the ray) to planar Z depth.
-
-        The batch renderer calls this per camera when ``use_rasterizer=False`` so depth output matches the planar
-        z-buffer convention used elsewhere. Mirrors ``genesis.vis.camera.Camera.distance_center_to_plane``.
-        """
-        width, height = self.res
-        fx = fy = self.f
-        cx = self.cx
-        cy = self.cy
-        v, u = torch.meshgrid(
-            torch.arange(height, dtype=torch.int32, device=gs.device),
-            torch.arange(width, dtype=torch.int32, device=gs.device),
-            indexing="ij",
-        )
-        xd = (u + 0.5 - cx) / fx
-        yd = (v + 0.5 - cy) / fy
-        scale_inv = torch.rsqrt(xd**2 + yd**2 + 1.0)
-        return center_dis * scale_inv
+    def colorize_seg_idxc_arr(self, seg_idxc_arr):
+        if self.batch_renderer is not None:
+            return self.batch_renderer.colorize_seg_idxc_arr(seg_idxc_arr)
+        return self._context.colorize_seg_idxc_arr(seg_idxc_arr)
 
 
 # ========================== Shared Metadata ==========================
@@ -209,10 +122,13 @@ class BatchRendererCameraWrapper(BaseCameraWrapper):
 class RasterizerCameraSharedMetadata(KinematicSensorMetadataMixin, SharedSensorMetadata):
     """Shared metadata for all Rasterizer cameras."""
 
-    # Rasterizer instance
+    # Rasterizer instance (the visualizer's when a viewer exists, else a standalone one)
     renderer: Optional["Rasterizer"] = None
     # RasterizerContext instance
     context: Optional["RasterizerContext"] = None
+    # The `CameraBackendProvider` the owned `vis.Camera`s build/render against (the `Visualizer` when a viewer exists,
+    # else a `StandaloneCameraBackend`).
+    backend: Optional[Any] = None
     # List of light dictionaries
     lights: Optional[List[Dict[str, Any]]] = None
     # List of RasterizerCameraSensor instances
@@ -229,6 +145,7 @@ class RasterizerCameraSharedMetadata(KinematicSensorMetadataMixin, SharedSensorM
         if self.context is not None:
             self.context.destroy()
             self.context = None
+        self.backend = None
         self.lights = None
         self.sensors = None
 
@@ -265,15 +182,17 @@ class BatchRendererCameraSharedMetadata(KinematicSensorMetadataMixin, SharedSens
     sensors: Optional[List["BatchRendererCameraSensor"]] = None
     # Track when batch was last rendered
     last_render_timestep: int = -1
-    # MinimalVisualizerWrapper instance
-    visualizer_wrapper: Optional["MinimalVisualizerWrapper"] = None
+    # StandaloneCameraBackend the owned `vis.Camera`s build against and which the batch renderer enumerates.
+    backend: Optional["StandaloneCameraBackend"] = None
 
     def destroy(self):
         super().destroy()
 
         self.renderer = None
         self.sensors = None
-        self.visualizer_wrapper = None
+        if self.backend is not None and self.backend.context is not None:
+            self.backend.context.destroy()
+        self.backend = None
 
 
 # ========================== Base Camera Sensor ==========================
@@ -311,6 +230,9 @@ class BaseCameraSensor(KinematicSensorMixin, Sensor[OptionsT, None, SharedSensor
         super().__init__(options, idx, shared_context, shared_metadata, manager)
         self._enabled: tuple[str, ...] = _enabled_modalities(options)
         self._stale: bool = True
+        # The owned `vis.Camera`; created lazily in each backend's `build`/first render. All pose / intrinsics /
+        # rendering is delegated to it, so the sensor holds no duplicate pose or camera-matrix state.
+        self._camera: Optional["Camera"] = None
 
     # ========================== Cache Integration (shared) ==========================
 
@@ -386,43 +308,102 @@ class BaseCameraSensor(KinematicSensorMixin, Sensor[OptionsT, None, SharedSensor
         """No debug drawing for cameras."""
         pass
 
-    # ========================== Attachment handling ==========================
+    # ========================== Attachment / pose ==========================
 
-    @gs.assert_built
-    def move_to_attach(self):
+    def _init_camera_pose(self):
         """
-        Move the camera to follow the currently attached rigid link.
-
-        Uses a shared transform computation and delegates to _apply_camera_transform().
+        Bind the owned `vis.Camera`'s pose to this sensor's options: attach to the configured link (offset from
+        `offset_T`, or from `pos`/`lookat`/`up`), or leave the static world pose already set at `Camera.build`.
+        Per-step tracking then happens through `vis.Camera.move_to_attach`.
         """
         if self._link is None:
-            gs.raise_exception("Camera not attached to any rigid link.")
-
+            return
         if self._options.offset_T is not None:
-            offset_T = torch.tensor(self._options.offset_T, dtype=gs.tc_float, device=gs.device)
+            offset_T = torch.as_tensor(self._options.offset_T, dtype=gs.tc_float, device=gs.device)
         else:
-            pos = torch.tensor(self._options.pos, dtype=gs.tc_float, device=gs.device)
-            lookat = torch.tensor(self._options.lookat, dtype=gs.tc_float, device=gs.device)
-            up = torch.tensor(self._options.up, dtype=gs.tc_float, device=gs.device)
-            offset_T = pos_lookat_up_to_T(pos, lookat, up)
-
-        link_pos = self._link.get_pos(relative=False)
-        link_quat = self._link.get_quat(relative=False)
-
-        link_T = trans_quat_to_T(link_pos, link_quat)
-        camera_T = torch.matmul(link_T, offset_T)
-
-        self._apply_camera_transform(camera_T)
+            offset_T = pos_lookat_up_to_T(
+                torch.as_tensor(self._options.pos, dtype=gs.tc_float, device=gs.device),
+                torch.as_tensor(self._options.lookat, dtype=gs.tc_float, device=gs.device),
+                torch.as_tensor(self._options.up, dtype=gs.tc_float, device=gs.device),
+            )
+        self._camera.attach(self._link, offset_T)
 
     # ========================== Hooks for subclasses ==========================
-
-    def _apply_camera_transform(self, camera_T: torch.Tensor):
-        """Apply the computed camera transform to the backend-specific camera representation."""
-        raise NotImplementedError
 
     def _render_current_state(self):
         """Perform the actual render for the current state; subclasses must implement."""
         raise NotImplementedError
+
+    # ========================== Capability delegation to the owned vis.Camera ==========================
+
+    @property
+    def camera(self) -> "Camera":
+        """The underlying `vis.Camera` this sensor renders through (pose, intrinsics, extrinsics, ...)."""
+        return self._camera
+
+    @gs.assert_built
+    def set_pose(self, transform=None, pos=None, lookat=None, up=None, envs_idx=None):
+        """Set the camera pose. Delegates to `vis.Camera.set_pose` (per-env when batched)."""
+        self._camera.set_pose(transform=transform, pos=pos, lookat=lookat, up=up, envs_idx=envs_idx)
+        # Invalidate the lazy-render cache so the next read re-renders from the new pose within the same step.
+        self._stale = True
+
+    @gs.assert_built
+    def get_pos(self, envs_idx=None):
+        return self._camera.get_pos(envs_idx)
+
+    @gs.assert_built
+    def get_quat(self, envs_idx=None):
+        return self._camera.get_quat(envs_idx)
+
+    @gs.assert_built
+    def get_transform(self, envs_idx=None):
+        return self._camera.get_transform(envs_idx)
+
+    @gs.assert_built
+    def get_lookat(self, envs_idx=None):
+        return self._camera.get_lookat(envs_idx)
+
+    @gs.assert_built
+    def get_up(self, envs_idx=None):
+        return self._camera.get_up(envs_idx)
+
+    @property
+    def intrinsics(self):
+        """The camera intrinsics matrix `K`."""
+        return self._camera.intrinsics
+
+    @property
+    def extrinsics(self):
+        """The camera extrinsics (world-to-camera) matrix."""
+        return self._camera.extrinsics
+
+    @property
+    def projection_matrix(self):
+        """The OpenGL projection matrix."""
+        return self._camera.projection_matrix
+
+    @property
+    def f(self):
+        """The focal length in pixels."""
+        return self._camera.f
+
+    @property
+    def cx(self):
+        return self._camera.cx
+
+    @property
+    def cy(self):
+        return self._camera.cy
+
+    def distance_center_to_plane(self, center_dis):
+        """Convert Euclidean center distance (range along the ray) to planar Z depth."""
+        return self._camera.distance_center_to_plane(center_dis)
+
+    @gs.assert_built
+    def render_pointcloud(self, world_frame=True):
+        """Render a partial point cloud from the camera view (depth-deprojected)."""
+        return self._camera.render_pointcloud(world_frame=world_frame)
 
     # ========================== Shared read() ==========================
 
@@ -443,11 +424,7 @@ class BaseCameraSensor(KinematicSensorMixin, Sensor[OptionsT, None, SharedSensor
         if not self._stale:
             return
 
-        # Update camera pose only when attached; detached cameras keep their last world pose
-        if self._link is not None:
-            self.move_to_attach()
-
-        # Call subclass-specific render
+        # Build the owned vis.Camera (deferred on the viewer-shared path), track the attached link, then render.
         self._render_current_state()
 
         # Mark as fresh
@@ -524,10 +501,6 @@ class RasterizerCameraSensor(
     ):
         super().__init__(options, idx, shared_context, shared_metadata, manager)
         self._options: RasterizerCameraOptions
-        self._camera_node = None
-        self._camera_target = None
-        self._camera_wrapper = None
-        self._is_camera_registered = False
 
     # ========================== Sensor Lifecycle ==========================
 
@@ -541,16 +514,20 @@ class RasterizerCameraSensor(
             self._shared_metadata.sensors = []
             self._shared_metadata.lights = gs.List()
 
-            # If a viewer is active, reuse its windowed OpenGL context for both offscreen and onscreen rendering, rather
-            # than creating a separate headless context which is fragile.
+            # If a viewer is active, reuse its windowed OpenGL context (and the visualizer as the camera backend) for
+            # both offscreen and onscreen rendering, rather than a separate headless context which is fragile.
             if scene.viewer is not None:
                 self._shared_metadata.context = scene.visualizer.context
                 self._shared_metadata.renderer = scene.visualizer.rasterizer
+                self._shared_metadata.backend = scene.visualizer
             else:
-                # No viewer - create standalone rasterizer with offscreen context
-                self._shared_metadata.context = self._create_standalone_context(scene)
-                self._shared_metadata.renderer = Rasterizer(viewer=None, context=self._shared_metadata.context)
-                self._shared_metadata.renderer.build()
+                # No viewer - create standalone rasterizer with offscreen context + a standalone camera backend.
+                context = self._create_standalone_context(scene)
+                renderer = Rasterizer(viewer=None, context=context)
+                renderer.build()
+                self._shared_metadata.context = context
+                self._shared_metadata.renderer = renderer
+                self._shared_metadata.backend = StandaloneCameraBackend(scene, context, rasterizer=renderer)
 
         self._shared_metadata.sensors.append(self)
 
@@ -560,27 +537,36 @@ class RasterizerCameraSensor(
                 "for correct per-environment rendering."
             )
 
-        # Register camera now if standalone (offscreen), or defer to first render if using visualizer's rasterizer
-        # (visualizer isn't built yet at sensor.build() time)
+        # Build the owned vis.Camera now if the rasterizer is standalone (already built here), or defer to first render
+        # when sharing the visualizer's rasterizer (the visualizer isn't built yet at sensor.build() time).
         if self._shared_metadata.renderer.offscreen:
-            self._ensure_camera_registered()
+            self._build_camera()
 
-    def _ensure_camera_registered(self):
-        """Register this camera with the renderer (no-op if already registered)."""
-        if self._is_camera_registered:
+    def _build_camera(self):
+        """Construct + build this sensor's `vis.Camera` against the rasterizer backend (idempotent)."""
+        if self._camera is not None:
             return
 
-        # Add lights from options to the context
+        # Add this camera's lights to the shared context.
         for light_config in self._options.lights:
-            if self._shared_metadata.lights is not None:
-                light_dict = self._convert_light_config_to_rasterizer(light_config)
-                self._shared_metadata.context.add_light(light_dict)
+            self._shared_metadata.context.add_light(self._convert_light_config_to_rasterizer(light_config))
 
-        if self._camera_wrapper is None:
-            self._camera_wrapper = RasterizerCameraWrapper(self)
-        self._shared_metadata.renderer.add_camera(self._camera_wrapper)
-        self._update_camera_pose()
-        self._is_camera_registered = True
+        self._camera = Camera(
+            self._shared_metadata.backend,
+            idx=self._idx,
+            model="pinhole",
+            res=self._options.res,
+            pos=self._options.pos,
+            lookat=self._options.lookat,
+            up=self._options.up,
+            fov=self._options.fov,
+            near=self._options.near,
+            far=self._options.far,
+            GUI=False,
+            debug=False,
+        )
+        self._camera.build()
+        self._init_camera_pose()
 
     def _create_standalone_context(self, scene):
         """Create a simplified RasterizerContext for camera sensors."""
@@ -620,46 +606,16 @@ class RasterizerCameraSensor(
             dir = light_config.get("dir", (0.0, 0.0, -1.0))
             return DirectionalLight(dir=dir, color=color, intensity=intensity)
 
-    def _update_camera_pose(self):
-        """Update camera pose based on options."""
-        pos = torch.tensor(self._options.pos, dtype=gs.tc_float, device=gs.device)
-        lookat = torch.tensor(self._options.lookat, dtype=gs.tc_float, device=gs.device)
-        up = torch.tensor(self._options.up, dtype=gs.tc_float, device=gs.device)
-
-        # If attached to a link and the link is built, pos is relative to link frame
-        if self._link is not None and self._link.is_built:
-            # Convert pos from link-relative to world coordinates
-            link_pos = self._link.get_pos(relative=False)
-            link_quat = self._link.get_quat(relative=False)
-
-            # Apply pos directly as offset from link
-            pos_world = transform_by_quat(pos, link_quat) + link_pos
-            pos = pos_world
-        elif self._link is not None:
-            # Link exists but not built yet - use configured pose as-is (treat as world coordinates for now) This will
-            # be corrected when move_to_attach is called
-            pass
-
-        transform = pos_lookat_up_to_T(pos, lookat, up)
-        self._camera_wrapper.transform = tensor_to_array(transform)
-        self._shared_metadata.renderer.update_camera(self._camera_wrapper)
-
-    def _apply_camera_transform(self, camera_T: torch.Tensor):
-        """Update rasterizer camera wrapper from a world transform."""
-        self._ensure_camera_registered()
-        self._camera_wrapper.transform = tensor_to_array(camera_T)
-        self._shared_metadata.renderer.update_camera(self._camera_wrapper)
-
     def _render_current_state(self):
         """Perform the actual render for the current state."""
-        self._ensure_camera_registered()
+        self._build_camera()  # deferred build on the viewer-shared path
+        # Track the attached link; static cameras keep their build-time world pose. `set_pose` inside `move_to_attach`
+        # refreshes the rasterizer node pose.
+        if self._link is not None:
+            self._camera.move_to_attach()
 
         context = self._shared_metadata.context
 
-        # When env_separate_rigid is enabled, geometry render transforms include env_spacing offsets (baked in by
-        # kernel_update_geoms_render_T). For per-env sensor rendering, these offsets must be temporarily removed so each
-        # env's geometry renders at local origin relative to the camera. The offsets are restored after rendering to
-        # preserve the correct layout for the interactive viewer which shares the same context.
         context.update(force_render=True)
 
         # When env_separate_rigid is enabled, geometry render transforms include env_spacing offsets (baked in by
@@ -677,7 +633,7 @@ class RasterizerCameraSensor(
                     context.jit.update_buffer(node, "model", poses.transpose((0, 2, 1)))
 
         render_out = self._shared_metadata.renderer.render_camera(
-            self._camera_wrapper,
+            self._camera,
             rgb=self._options.render_rgb,
             depth=self._options.render_depth,
             segmentation=self._options.render_segmentation,
@@ -712,7 +668,6 @@ class RaytracerCameraSensor(
     ):
         super().__init__(options, idx, shared_context, shared_metadata, manager)
         self._options: RaytracerCameraOptions
-        self._camera_obj = None
 
     def build(self):
         """Register a raytracer camera that reuses the visualizer pipeline."""
@@ -754,32 +709,14 @@ class RaytracerCameraSensor(
             if not scene.is_built:
                 self._add_light_as_mesh_light(scene, light_config)
 
-        # Compute world pose for the camera
-        pos = torch.tensor(self._options.pos, dtype=gs.tc_float, device=gs.device)
-        lookat = torch.tensor(self._options.lookat, dtype=gs.tc_float, device=gs.device)
-        up = torch.tensor(self._options.up, dtype=gs.tc_float, device=gs.device)
-
-        # If attached to a link and the link is built, transform pos to world coordinates
-        if self._link is not None and self._link.is_built:
-            link_pos = self._link.get_pos(relative=False).squeeze(0)
-            link_quat = self._link.get_quat(relative=False).squeeze(0)
-
-            # Apply pos directly as offset from link
-            pos = transform_by_trans_quat(pos, link_pos, link_quat)
-
-            # Transform lookat and up (no rotation offset since rotation is defined by lookat/up)
-            lookat = transform_by_trans_quat(lookat, link_pos, link_quat)
-            up = transform_by_quat(up, link_quat)
-        elif self._link is not None:
-            # Link exists but not built yet - use configured pose as-is (treat as world coordinates for now) This will
-            # be corrected when move_to_attach is called
-            pass
-
-        self._camera_obj = visualizer.add_camera(
+        # Own a real vis.Camera built against the visualizer (the raytracer requires one). The initial pose uses the
+        # configured pos/lookat/up in world frame; when attached, `_init_camera_pose` binds the link and the per-step
+        # `move_to_attach` corrects the pose.
+        self._camera = visualizer.add_camera(
             res=self._options.res,
-            pos=pos,
-            lookat=lookat,
-            up=up,
+            pos=self._options.pos,
+            lookat=self._options.lookat,
+            up=self._options.up,
             model=self._options.model,
             fov=self._options.fov,
             aperture=self._options.aperture,
@@ -792,22 +729,7 @@ class RaytracerCameraSensor(
             env_idx=None if n_envs == 0 else 0,
             debug=False,
         )
-
-        # Attach the visualizer camera to the link if this sensor is attached
-        if self._link is not None:
-            if self._options.offset_T is not None:
-                offset_T = torch.tensor(self._options.offset_T, dtype=gs.tc_float, device=gs.device)
-            else:
-                pos = torch.tensor(self._options.pos, dtype=gs.tc_float, device=gs.device)
-                lookat = torch.tensor(self._options.lookat, dtype=gs.tc_float, device=gs.device)
-                up = torch.tensor(self._options.up, dtype=gs.tc_float, device=gs.device)
-                offset_T = pos_lookat_up_to_T(pos, lookat, up)
-            self._camera_obj.attach(self._link, offset_T)
-
-    @gs.assert_built
-    def move_to_attach(self):
-        # Bypass original implementation since it will be handled by visualizer
-        pass
+        self._init_camera_pose()
 
     def _add_light_as_mesh_light(self, scene, light_config):
         """Add a light as a mesh light to the scene."""
@@ -833,12 +755,12 @@ class RaytracerCameraSensor(
     def _render_current_state(self):
         """Perform the actual render for the current state."""
         if self._link is not None:
-            self._camera_obj.move_to_attach()
+            self._camera.move_to_attach()
 
         # Only RGB is path-traced; depth/segmentation/normal come from the rasterizer fallback inside `Camera.render`
         # (see `RaytracerCameraSensor.build` for the warning). `colorize_seg=False` yields the int32 index map, which is
         # the desired numeric sensor output.
-        render_out = self._camera_obj.render(
+        render_out = self._camera.render(
             rgb=self._options.render_rgb,
             depth=self._options.render_depth,
             segmentation=self._options.render_segmentation,
@@ -874,7 +796,6 @@ class BatchRendererCameraSensor(
     ):
         super().__init__(options, idx, shared_context, shared_metadata, manager)
         self._options: BatchRendererCameraOptions
-        self._camera_obj = None
 
     def build(self):
         """Initialize the batch renderer and register this camera."""
@@ -906,10 +827,15 @@ class BatchRendererCameraSensor(
                 rendered_envs_idx=range(max(self._manager._sim._B, 1)),
             )
 
-            self._shared_metadata.visualizer_wrapper = MinimalVisualizerWrapper(scene, all_sensors, vis_options)
-            self._shared_metadata.renderer = BatchRenderer(
-                self._shared_metadata.visualizer_wrapper, br_options, vis_options
-            )
+            # Standalone backend the owned vis.Cameras build against and which the batch renderer enumerates. The
+            # renderer must exist before the cameras build so `Camera.build` takes the batch branch.
+            context = RasterizerContext(vis_options)
+            context.build(scene)
+            context.reset()
+            backend = StandaloneCameraBackend(scene, context)
+            backend.batch_renderer = BatchRenderer(backend, br_options, vis_options)
+            self._shared_metadata.backend = backend
+            self._shared_metadata.renderer = backend.batch_renderer
 
         self._shared_metadata.sensors.append(self)
 
@@ -918,10 +844,27 @@ class BatchRendererCameraSensor(
             if self._shared_metadata.renderer is not None:
                 self._add_light_to_batch_renderer(light_config)
 
-        self._camera_obj = BatchRendererCameraWrapper(self)
+        # This sensor's vis.Camera is a pose/intrinsics holder the batch renderer enumerates (it does not drive
+        # per-sensor rendering; the single union pass in `_render_current_state` does).
+        self._camera = Camera(
+            self._shared_metadata.backend,
+            idx=self._idx,
+            model=self._options.model,
+            res=self._options.res,
+            pos=self._options.pos,
+            lookat=self._options.lookat,
+            up=self._options.up,
+            fov=self._options.fov,
+            near=self._options.near,
+            far=self._options.far,
+            GUI=False,
+            debug=False,
+        )
+        self._camera.build()
+        self._init_camera_pose()
 
         if len(self._shared_metadata.sensors) == len(self._manager._sensors_by_type[type(self)]):
-            self._shared_metadata.visualizer_wrapper._cameras = [s._camera_obj for s in self._shared_metadata.sensors]
+            self._shared_metadata.backend._cameras = [s._camera for s in self._shared_metadata.sensors]
             self._shared_metadata.renderer.build()
 
     def _render_current_state(self):
@@ -930,7 +873,7 @@ class BatchRendererCameraSensor(
 
         for sensor in sensors:
             if sensor._link is not None:
-                sensor.move_to_attach()
+                sensor._camera.move_to_attach()
 
         self._shared_metadata.renderer.update_scene(force_render=True)
 
@@ -962,12 +905,6 @@ class BatchRendererCameraSensor(
             sensor._stale = False
 
         self._shared_metadata.last_render_timestep = self._manager._sim.scene.t
-
-    def _apply_camera_transform(self, camera_T: torch.Tensor):
-        """Update batch renderer camera from a world transform."""
-        # Note: BatchRenderer will pick up the updated transform on next render
-        self._camera_obj.transform = camera_T
-        self._camera_obj._pos = T_to_trans(camera_T)
 
     def _add_light_to_batch_renderer(self, light_config):
         """Add a light to the batch renderer."""

--- a/genesis/engine/sensors/camera.py
+++ b/genesis/engine/sensors/camera.py
@@ -47,9 +47,76 @@ if TYPE_CHECKING:
 
 
 class CameraReturnType(NamedTuple):
-    """Camera sensor return data."""
+    """
+    Camera sensor return data.
 
-    rgb: torch.Tensor
+    Only the modalities enabled on the sensor options are populated; the rest are ``None``. ``rgb`` is kept first for
+    backward compatibility with code that unpacks or accesses ``.rgb``.
+    """
+
+    rgb: Optional[torch.Tensor] = None
+    depth: Optional[torch.Tensor] = None
+    segmentation: Optional[torch.Tensor] = None
+    normal: Optional[torch.Tensor] = None
+
+
+# Ordered to match the render backends' return tuple `(rgb, depth, segmentation, normal)` (see
+# `Rasterizer.render_camera`, `vis.Camera.render`, and `BatchRenderer.render` which returns in `IMAGE_TYPE` order).
+_CAMERA_MODALITIES = ("rgb", "depth", "segmentation", "normal")
+
+
+def _modality_dtype(name: str) -> torch.dtype:
+    """Per-pixel dtype for a modality: uint8 color, float32 depth/normal, int32 segmentation indices."""
+    if name == "rgb":
+        return torch.uint8
+    if name == "segmentation":
+        return torch.int32
+    return torch.float32
+
+
+def _modality_shape(name: str, B: int, w: int, h: int) -> tuple[int, ...]:
+    """Cache buffer shape for a modality. rgb/normal are 3-channel; depth/segmentation are single-channel."""
+    if name in ("rgb", "normal"):
+        return (B, h, w, 3)
+    return (B, h, w)
+
+
+def _enabled_modalities(options) -> tuple[str, ...]:
+    return tuple(name for name in _CAMERA_MODALITIES if getattr(options, f"render_{name}"))
+
+
+def _allocate_image_cache(options, B: int, w: int, h: int) -> Dict[str, torch.Tensor]:
+    """Allocate one zero buffer per enabled modality, keyed by modality name."""
+    return {
+        name: torch.zeros(_modality_shape(name, B, w, h), dtype=_modality_dtype(name), device=gs.device)
+        for name in _enabled_modalities(options)
+    }
+
+
+def _to_cache_tensor(arr, dtype: torch.dtype) -> torch.Tensor:
+    """Convert a rendered array (numpy, possibly with negative strides, or torch/CUDA) to a contiguous typed tensor."""
+    if isinstance(arr, torch.Tensor):
+        return arr.to(dtype=dtype, device=gs.device).contiguous()
+    return torch.from_numpy(np.ascontiguousarray(arr)).to(dtype=dtype, device=gs.device)
+
+
+def _store_render_into_cache(cache: Dict[str, torch.Tensor], render_tuple, dst=slice(None)):
+    """
+    Scatter a backend render tuple `(rgb, depth, segmentation, normal)` into the per-modality cache at index `dst`.
+
+    Only modalities present in `cache` and non-None in `render_tuple` are written. A single-env render (missing the
+    batch dim) is unsqueezed to match the cache's leading batch dimension.
+    """
+    for name, arr in zip(_CAMERA_MODALITIES, render_tuple):
+        if name not in cache or arr is None:
+            continue
+        buf = cache[name]
+        target = buf[dst]
+        t = _to_cache_tensor(arr, buf.dtype)
+        if t.ndim == target.ndim - 1:
+            # Single-environment render missing the batch dim; add it to match the destination slice.
+            t = t.unsqueeze(0)
+        buf[dst] = t
 
 
 class MinimalVisualizerWrapper:
@@ -127,6 +194,40 @@ class BatchRendererCameraWrapper(BaseCameraWrapper):
             return quat
         return quat[None].expand((n_envs, -1))
 
+    # Pinhole intrinsics, mirroring `genesis.vis.camera.Camera` (f/cx/cy), needed by `distance_center_to_plane`.
+    @property
+    def f(self):
+        return 0.5 * self.res[1] / np.tan(np.deg2rad(0.5 * self.fov))
+
+    @property
+    def cx(self):
+        return 0.5 * self.res[0]
+
+    @property
+    def cy(self):
+        return 0.5 * self.res[1]
+
+    def distance_center_to_plane(self, center_dis):
+        """
+        Convert Euclidean center distance (range along the ray) to planar Z depth.
+
+        The batch renderer calls this per camera when ``use_rasterizer=False`` so depth output matches the planar
+        z-buffer convention used elsewhere. Mirrors ``genesis.vis.camera.Camera.distance_center_to_plane``.
+        """
+        width, height = self.res
+        fx = fy = self.f
+        cx = self.cx
+        cy = self.cy
+        v, u = torch.meshgrid(
+            torch.arange(height, dtype=torch.int32, device=gs.device),
+            torch.arange(width, dtype=torch.int32, device=gs.device),
+            indexing="ij",
+        )
+        xd = (u + 0.5 - cx) / fx
+        yd = (v + 0.5 - cy) / fy
+        scale_inv = torch.rsqrt(xd**2 + yd**2 + 1.0)
+        return center_dis * scale_inv
+
 
 # ========================== Shared Metadata ==========================
 
@@ -143,8 +244,9 @@ class RasterizerCameraSharedMetadata(KinematicSensorMetadataMixin, SharedSensorM
     lights: Optional[List[Dict[str, Any]]] = None
     # List of RasterizerCameraSensor instances
     sensors: Optional[List["RasterizerCameraSensor"]] = None
-    # {sensor_idx: np.ndarray with shape (B, H, W, 3)}
-    image_cache: Optional[Dict[int, np.ndarray]] = None
+    # {sensor_idx: {modality_name: torch.Tensor}}; rgb (B,H,W,3) uint8, depth (B,H,W) f32, segmentation (B,H,W) i32,
+    # normal (B,H,W,3) f32. Only enabled modalities are allocated (see `_allocate_image_cache`).
+    image_cache: Optional[Dict[int, Dict[str, "torch.Tensor"]]] = None
     # Track when rasterizer cameras were last updated
     last_render_timestep: int = -1
 
@@ -172,8 +274,9 @@ class RaytracerCameraSharedMetadata(KinematicSensorMetadataMixin, SharedSensorMe
     lights: Optional[List[Any]] = None
     # List of RaytracerCameraSensor instances
     sensors: Optional[List["RaytracerCameraSensor"]] = None
-    # {sensor_idx: np.ndarray with shape (B, H, W, 3)}
-    image_cache: Optional[Dict[int, np.ndarray]] = None
+    # {sensor_idx: {modality_name: torch.Tensor}}; rgb (B,H,W,3) uint8, depth (B,H,W) f32, segmentation (B,H,W) i32,
+    # normal (B,H,W,3) f32. Only enabled modalities are allocated (see `_allocate_image_cache`).
+    image_cache: Optional[Dict[int, Dict[str, "torch.Tensor"]]] = None
     # Track when raytracer cameras were last updated
     last_render_timestep: int = -1
 
@@ -195,8 +298,9 @@ class BatchRendererCameraSharedMetadata(KinematicSensorMetadataMixin, SharedSens
     lights: Optional[Any] = None
     # List of BatchRendererCameraSensor instances
     sensors: Optional[List["BatchRendererCameraSensor"]] = None
-    # {sensor_idx: np.ndarray with shape (B, H, W, 3)}
-    image_cache: Optional[Dict[int, np.ndarray]] = None
+    # {sensor_idx: {modality_name: torch.Tensor}}; rgb (B,H,W,3) uint8, depth (B,H,W) f32, segmentation (B,H,W) i32,
+    # normal (B,H,W,3) f32. Only enabled modalities are allocated (see `_allocate_image_cache`).
+    image_cache: Optional[Dict[int, Dict[str, "torch.Tensor"]]] = None
     # Track when batch was last rendered
     last_render_timestep: int = -1
     # MinimalVisualizerWrapper instance
@@ -226,6 +330,10 @@ class BaseCameraSensor(KinematicSensorMixin, Sensor[OptionsT, None, SharedSensor
     """
 
     uses_ring_pipeline: ClassVar[bool] = False
+    # Cameras store multi-dtype images (uint8 rgb / float32 depth+normal / int32 seg) in their own `image_cache` and are
+    # read via `sensor.read()`. The manager's per-class cache is single-dtype, so cameras opt out of it entirely; this
+    # also excludes them from `scene.read_sensors()`.
+    uses_manager_cache: ClassVar[bool] = False
 
     def __init__(
         self,
@@ -241,6 +349,9 @@ class BaseCameraSensor(KinematicSensorMixin, Sensor[OptionsT, None, SharedSensor
 
     # ========================== Cache Integration (shared) ==========================
 
+    # NOTE: `_get_return_format`/`_get_cache_dtype` are vestigial for cameras. Because `uses_manager_cache = False`, the
+    # manager skips cache-size accounting for camera classes, so these values are not used to size any buffer; camera
+    # output lives in the multi-dtype `image_cache` instead. They are kept only to satisfy the `Sensor` contract.
     def _get_return_format(self) -> tuple[tuple[int, ...], ...]:
         w, h = self._options.res
         return ((h, w, 3),)
@@ -357,28 +468,33 @@ class BaseCameraSensor(KinematicSensorMixin, Sensor[OptionsT, None, SharedSensor
 # ========================== Camera Sensor Helpers ==========================
 def _camera_read_from_image_cache(sensor, cached_image, envs_idx, *, to_numpy: bool) -> CameraReturnType:
     """
-    Shared helper to convert a cached RGB image array into CameraReturnType with correct env handling.
+    Convert a per-modality image cache into a CameraReturnType with correct env handling.
 
     Parameters
     ----------
     sensor : any camera sensor with _manager and _return_data_class
-    cached_image : np.ndarray | torch.Tensor
-        Image cache for this camera, shaped (B, H, W, 3) or (H, W, 3) depending on n_envs.
+    cached_image : dict[str, torch.Tensor]
+        Per-modality image cache for this camera; each buffer is shaped (B, H, W[, 3]). Only enabled modalities are
+        present; the rest of the returned NamedTuple stays None.
     envs_idx : None | int | sequence
         Environment index/indices to select.
     to_numpy : bool
-        If True and cached_image is a torch Tensor, convert to numpy first.
+        If True, convert each returned buffer to numpy.
     """
-    if to_numpy and isinstance(cached_image, torch.Tensor):
-        cached_image = tensor_to_array(cached_image)
+    n_envs = sensor._manager._sim.n_envs
 
-    if envs_idx is None:
-        if sensor._manager._sim.n_envs == 0:
-            return sensor._return_data_class(rgb=cached_image[0])
-        return sensor._return_data_class(rgb=cached_image)
-    if isinstance(envs_idx, (int, np.integer)):
-        return sensor._return_data_class(rgb=cached_image[envs_idx])
-    return sensor._return_data_class(rgb=cached_image[envs_idx])
+    def select_envs(buf):
+        if envs_idx is None:
+            buf = buf[0] if n_envs == 0 else buf
+        elif isinstance(envs_idx, (int, np.integer)):
+            buf = buf[envs_idx]
+        else:
+            buf = buf[envs_idx]
+        if to_numpy and isinstance(buf, torch.Tensor):
+            buf = tensor_to_array(buf)
+        return buf
+
+    return sensor._return_data_class(**{name: select_envs(buf) for name, buf in cached_image.items()})
 
 
 # ========================== Rasterizer Camera Sensor ==========================
@@ -448,7 +564,7 @@ class RasterizerCameraSensor(
 
         _B = max(self._manager._sim.n_envs, 1)
         w, h = self._options.res
-        self._shared_metadata.image_cache[self._idx] = torch.zeros((_B, h, w, 3), dtype=torch.uint8, device=gs.device)
+        self._shared_metadata.image_cache[self._idx] = _allocate_image_cache(self._options, _B, w, h)
 
     def _ensure_camera_registered(self):
         """Register this camera with the renderer (no-op if already registered)."""
@@ -561,8 +677,12 @@ class RasterizerCameraSensor(
                     poses[:, :3, 3] -= envs_offset[context.rendered_envs_idx]
                     context.jit.update_buffer(node, "model", poses.transpose((0, 2, 1)))
 
-        rgb_arr, _, _, _ = self._shared_metadata.renderer.render_camera(
-            self._camera_wrapper, rgb=True, depth=False, segmentation=False, normal=False
+        render_out = self._shared_metadata.renderer.render_camera(
+            self._camera_wrapper,
+            rgb=self._options.render_rgb,
+            depth=self._options.render_depth,
+            segmentation=self._options.render_segmentation,
+            normal=self._options.render_normal,
         )
 
         # Restore original geometry transforms with offsets for the interactive viewer
@@ -571,13 +691,9 @@ class RasterizerCameraSensor(
             node.mesh.primitives[0].poses = poses
             context.jit.update_buffer(node, "model", poses.transpose((0, 2, 1)))
 
-        # Ensure contiguous layout because the rendered array may have negative strides.
-        rgb_tensor = torch.from_numpy(np.ascontiguousarray(rgb_arr)).to(dtype=torch.uint8, device=gs.device)
-
-        if len(rgb_tensor.shape) == 3:
-            # Single environment rendered - add batch dimension.
-            rgb_tensor = rgb_tensor.unsqueeze(0)
-        self._shared_metadata.image_cache[self._idx][:] = rgb_tensor
+        # Scatter each requested modality into the per-modality cache. `_store_render_into_cache` handles negative
+        # strides, dtype casting, and adding the batch dim for single-environment renders.
+        _store_render_into_cache(self._shared_metadata.image_cache[self._idx], render_out)
 
 
 # ========================== Raytracer Camera Sensor ==========================
@@ -611,6 +727,12 @@ class RaytracerCameraSensor(
         if renderer is None:
             gs.raise_exception(
                 "RaytracerCameraSensor requires the scene to be created with `renderer=gs.renderers.RayTracer(...)`."
+            )
+
+        if self._options.render_depth or self._options.render_segmentation or self._options.render_normal:
+            gs.logger.warning(
+                "Raytracer camera sensor: only RGB is path-traced. `depth`, `segmentation` and `normal` are produced "
+                "by the rasterizer fallback (geometry-correct, but not path-traced) and require an OpenGL context."
             )
 
         # Multi-environment rendering is not yet supported for Raytracer cameras
@@ -687,7 +809,7 @@ class RaytracerCameraSensor(
 
         _B = max(n_envs, 1)
         w, h = self._options.res
-        self._shared_metadata.image_cache[self._idx] = torch.zeros((_B, h, w, 3), dtype=torch.uint8, device=gs.device)
+        self._shared_metadata.image_cache[self._idx] = _allocate_image_cache(self._options, _B, w, h)
 
     @gs.assert_built
     def move_to_attach(self):
@@ -720,19 +842,20 @@ class RaytracerCameraSensor(
         if self._link is not None:
             self._camera_obj.move_to_attach()
 
-        rgb_arr, _, _, _ = self._camera_obj.render(
-            rgb=True,
-            depth=False,
-            segmentation=False,
+        # Only RGB is path-traced; depth/segmentation/normal come from the rasterizer fallback inside `Camera.render`
+        # (see `RaytracerCameraSensor.build` for the warning). `colorize_seg=False` yields the int32 index map, which is
+        # the desired numeric sensor output.
+        render_out = self._camera_obj.render(
+            rgb=self._options.render_rgb,
+            depth=self._options.render_depth,
+            segmentation=self._options.render_segmentation,
             colorize_seg=False,
-            normal=False,
+            normal=self._options.render_normal,
             antialiasing=False,
             force_render=True,
         )
-        # Ensure contiguous layout because the rendered array may have negative strides.
-        rgb_tensor = torch.from_numpy(np.ascontiguousarray(rgb_arr)).to(dtype=torch.uint8, device=gs.device)
-
-        self._shared_metadata.image_cache[self._idx][0] = rgb_tensor
+        # Raytracer camera sensors reject n_envs > 1, so the render is a single (non-batched) frame -> store into slot 0.
+        _store_render_into_cache(self._shared_metadata.image_cache[self._idx], render_out, dst=0)
 
 
 # ========================== Batch Renderer Camera Sensor ==========================
@@ -810,7 +933,7 @@ class BatchRendererCameraSensor(
 
         _B = max(self._manager._sim.n_envs, 1)
         w, h = self._options.res
-        self._shared_metadata.image_cache[self._idx] = torch.zeros((_B, h, w, 3), dtype=torch.uint8, device=gs.device)
+        self._shared_metadata.image_cache[self._idx] = _allocate_image_cache(self._options, _B, w, h)
 
     def _render_current_state(self):
         """Perform the actual render for the current state."""
@@ -822,18 +945,31 @@ class BatchRendererCameraSensor(
 
         self._shared_metadata.renderer.update_scene(force_render=True)
 
-        rgb_arr, *_ = self._shared_metadata.renderer.render(
-            rgb=True, depth=False, segmentation=False, normal=False, antialiasing=False, force_render=True
+        # The batch renderer renders ALL cameras in a single pass with one set of flags, so request the union of the
+        # modalities across all batch camera sensors, then write only each sensor's own requested buffers below.
+        union = {name: any(getattr(s._options, f"render_{name}") for s in sensors) for name in _CAMERA_MODALITIES}
+        render_out = self._shared_metadata.renderer.render(
+            rgb=union["rgb"],
+            depth=union["depth"],
+            segmentation=union["segmentation"],
+            normal=union["normal"],
+            antialiasing=False,
+            force_render=True,
         )
 
-        # rgb_arr might be a tuple of arrays (one per camera) or a single array
-        if isinstance(rgb_arr, (tuple, list)):
-            rgb_arrs = [torch.as_tensor(arr).to(dtype=torch.uint8, device=gs.device) for arr in rgb_arr]
-        else:
-            rgb_arrs = torch.as_tensor(rgb_arr).to(dtype=torch.uint8, device=gs.device)
-
-        for sensor, rgb_arr in zip(sensors, rgb_arrs):
-            sensor._shared_metadata.image_cache[sensor._idx][:] = rgb_arr
+        # render_out is `(rgb, depth, segmentation, normal)`, each either None (not requested) or a per-camera sequence
+        # of arrays (one entry per camera in `sensors`). Regroup into a per-sensor render tuple and scatter.
+        per_camera = []
+        for arrs in render_out:
+            if arrs is None:
+                per_camera.append([None] * len(sensors))
+            elif isinstance(arrs, (tuple, list)):
+                per_camera.append(list(arrs))
+            else:
+                per_camera.append([arrs])
+        for cam_i, sensor in enumerate(sensors):
+            sensor_render = tuple(per_camera[mod_i][cam_i] for mod_i in range(len(_CAMERA_MODALITIES)))
+            _store_render_into_cache(sensor._shared_metadata.image_cache[sensor._idx], sensor_render)
             sensor._stale = False
 
         self._shared_metadata.last_render_timestep = self._manager._sim.scene.t

--- a/genesis/engine/sensors/sensor_manager.py
+++ b/genesis/engine/sensors/sensor_manager.py
@@ -155,6 +155,19 @@ class SensorManager:
             intermediate_dtype_by_class[sensor_cls] = intermediate_dtype
             return_dtype_by_class[sensor_cls] = return_dtype
 
+            if not sensor_cls.uses_manager_cache:
+                # Cameras own their multi-dtype `image_cache` and are read via `sensor.read()`. Register the dtype (so
+                # the paired intermediate cache exists for the empty per-step / reset slices) but contribute zero size,
+                # and assign an empty per-class slice. This avoids allocating a dead per-camera buffer and keeps
+                # `step()` / `reset()` slicing valid without special-casing them there.
+                cache_size_per_dtype.setdefault(intermediate_dtype, 0)
+                empty_at = cache_size_per_dtype[intermediate_dtype]
+                self._cache_slices_by_type[sensor_cls] = slice(empty_at, empty_at)
+                self._entity_slice_in_class[sensor_cls] = {}
+                self._max_history_by_class[sensor_cls] = 0
+                delay_depth_by_class[sensor_cls] = 1
+                continue
+
             cache_size_per_dtype.setdefault(intermediate_dtype, 0)
             cls_cache_start_idx = cache_size_per_dtype[intermediate_dtype]
             entity_offsets: dict[int, list[int]] = {}
@@ -447,6 +460,9 @@ class SensorManager:
 
         result: dict[int, torch.Tensor] = {}
         for sensor_cls, sensors in self._sensors_by_type.items():
+            if not sensor_cls.uses_manager_cache:
+                # Cameras store multi-dtype images in their own cache; read them via `sensor.read()`, not here.
+                continue
             entity_slice_map = self._entity_slice_in_class.get(sensor_cls, {})
             if entity_idx is None:
                 cls_slice = self._cache_slices_by_type[sensor_cls]

--- a/genesis/engine/sensors/sensor_manager.py
+++ b/genesis/engine/sensors/sensor_manager.py
@@ -594,6 +594,13 @@ class SensorManager:
             if sensor._options.entity_idx == target_eid
         )
 
+    def class_has_return_ring(self, sensor_cls: type["Sensor"]) -> bool:
+        """
+        Whether a sensor class has a per-class return-space ring (allocated for delay / history / a `_post_process`
+        override). Cameras use this to decide eager (per-step) vs lazy (on-read) rendering.
+        """
+        return sensor_cls in self._measured_return_timeline_ring
+
     @property
     def camera_sensors(self) -> "gs.List[Sensor]":
         """The camera sensors in the scene - the ones excluded from `read_sensors` and read via `read_cameras`."""

--- a/genesis/engine/sensors/sensor_manager.py
+++ b/genesis/engine/sensors/sensor_manager.py
@@ -31,31 +31,36 @@ class SensorManager:
         # `(cols, B)` for C-contiguous per-class row slices required by kernel writes.
         self._ground_truth_intermediate_cache: dict[type[torch.dtype], torch.Tensor] = {}
         self._intermediate_cache: dict[type[torch.dtype], torch.Tensor] = {}
-        # Per-class return caches in return space - what `read()` and `read_ground_truth()` slice into. Separate buffers
-        # when a per-class return-space ring is allocated (the orchestrator delay-samples the ring into the cache);
-        # alias-views into the per-dtype intermediate cache otherwise (identity `_post_process`, no delay, no history -
-        # the per-step write inside `_update_shared_cache` is then directly visible to `read()`).
-        self._return_cache: dict[type["Sensor"], torch.Tensor] = {}
-        self._ground_truth_return_cache: dict[type["Sensor"], torch.Tensor] = {}
+        # Per-class return caches in return space - what `read()` and `read_ground_truth()` slice into, keyed by return
+        # dtype (a multi-dtype sensor class, e.g. a camera, has one cache per dtype it spans). Separate buffers when a
+        # per-class return-space ring is allocated (the orchestrator delay-samples the ring into the cache); alias-views
+        # into the per-dtype intermediate cache otherwise (identity `_post_process`, no delay, no history - the per-step
+        # write inside `_update_shared_cache` is then directly visible to `read()`).
+        self._return_cache: dict[type["Sensor"], dict[torch.dtype, torch.Tensor]] = {}
+        self._ground_truth_return_cache: dict[type["Sensor"], dict[torch.dtype, torch.Tensor]] = {}
         # Paired GT and measured timeline rings (post-transform, PRE-hardware-imperfections data). Allocated together
         # per dtype when any sensor in the dtype declares `uses_ring_pipeline = True`. They share the same rotation idx
         # so a single `rotate()` per step advances both.
         self._ground_truth_timeline_ring: dict[type[torch.dtype], TensorRingBuffer] = {}
         self._measured_timeline_ring: dict[type[torch.dtype], TensorRingBuffer] = {}
-        # Per-class return-space rings (post-everything: post-hardware-imperfections, post-`_post_process`,
-        # pre-delay-sample). Allocated together when any sensor in the class has `delay > 0`, OR `history_length > 0`,
-        # OR the class overrides `_post_process`. Each step the post-everything snapshot is written to slot 0; the
-        # source for delay sampling (into the per-class return cache) and for history reads. GT and measured rings share
-        # their rotation idx so a single `rotate()` per step advances both.
-        self._ground_truth_return_timeline_ring: dict[type["Sensor"], TensorRingBuffer] = {}
-        self._measured_return_timeline_ring: dict[type["Sensor"], TensorRingBuffer] = {}
+        # Per-(class, return-dtype) return-space rings (post-everything: post-hardware-imperfections, post-
+        # `_post_process`, pre-delay-sample). Allocated when any sensor in the class has `delay > 0`, OR
+        # `history_length > 0`, OR the class overrides `_post_process`. Each step the post-everything snapshot is
+        # written to slot 0; the source for delay sampling (into the per-class return cache) and for history reads. GT
+        # and measured rings share their rotation idx so a single `rotate()` per step advances both.
+        self._ground_truth_return_timeline_ring: dict[type["Sensor"], dict[torch.dtype, TensorRingBuffer]] = {}
+        self._measured_return_timeline_ring: dict[type["Sensor"], dict[torch.dtype, TensorRingBuffer]] = {}
         # Per-class precomputed history index tensor [0, 1, ..., max_history-1]. Used to fancy-index the rings on
         # history reads.
         self._hist_idx_by_class: dict[type["Sensor"], torch.Tensor] = {}
-        self._cache_slices_by_type: dict[type["Sensor"], slice] = {}
-        # (sensor class, entity_idx) -> slice within the class cache. entity_idx == -1 means static sensors.
+        # Per-class contiguous slice into each INTERMEDIATE dtype buffer the class spans.
+        self._cache_slices_by_type: dict[type["Sensor"], dict[torch.dtype, slice]] = {}
+        # Per (sensor class, entity_idx) -> slice within the class return cache (relative). entity_idx == -1 means
+        # static sensors. Only meaningful/used for single-dtype ring-pipeline classes (the ones in `read_sensors()`).
         self._entity_slice_in_class: dict[type["Sensor"], dict[int, slice]] = {}
         self._max_history_by_class: dict[type["Sensor"], int] = {}
+        # Per-(class, return-dtype) ordered `(global_sensor_idx, size_in_dtype)` list driving `_apply_delay`.
+        self._delay_layout_by_type: dict[type["Sensor"], dict[torch.dtype, list[tuple[int, int]]]] = {}
 
     def create_sensor(self, sensor_options: "SensorOptions") -> "Sensor":
         sensor_options.validate_scene(self._sim.scene)
@@ -139,51 +144,48 @@ class SensorManager:
             for new_idx, sensor in enumerate(sensors):
                 sensor._idx = new_idx
 
-        # Per-class intermediate / return dtypes come from `_get_intermediate_dtype` / `_get_cache_dtype`. Dtype is
-        # class-uniform by design (the per-class slice into the per-dtype intermediate buffer must be contiguous, so all
-        # instances of a class share one dtype). Shape is per-instance via `_get_intermediate_format` /
-        # `_get_return_format` and contributes to the class slice size below.
+        # Field dtypes come from `_get_intermediate_dtype` / `_get_cache_dtype` (single dtype, or one per field). A
+        # sensor's fields are grouped by dtype (`sensor._intermediate_size_by_dtype` / `_return_size_by_dtype`), so a
+        # multi-dtype sensor (a camera: uint8 rgb / float32 depth+normal / int32 seg) contributes a contiguous column
+        # run to EACH dtype's buffer. Each class occupies one contiguous slice per dtype it spans; because a class's
+        # sensors are processed consecutively, that per-dtype slice stays contiguous.
+        #
+        # Ring-pipeline classes are laid out FIRST within each dtype so their columns form a contiguous prefix
+        # [0, timeline_size_per_dtype); the `_apply_transform` timeline rings then cover only that prefix and never the
+        # (potentially huge) image columns of non-ring camera classes. `timeline_size_per_dtype` is snapshotted at the
+        # ring/non-ring boundary.
         cache_size_per_dtype: dict[torch.dtype, int] = {}
         max_history_per_dtype: dict[torch.dtype, int] = {}
-        intermediate_dtype_by_class: dict[type["Sensor"], torch.dtype] = {}
-        return_dtype_by_class: dict[type["Sensor"], torch.dtype] = {}
+        timeline_size_per_dtype: dict[torch.dtype, int] | None = None
         # Per-class delay-depth (max sensor `_delay_ts + 1`) drives the return-space ring sizing for delay sampling.
         delay_depth_by_class: dict[type["Sensor"], int] = {}
-        for sensor_cls, sensors in self._sensors_by_type.items():
-            intermediate_dtype = sensor_cls._get_intermediate_dtype()
-            return_dtype = sensor_cls._get_cache_dtype()
-            intermediate_dtype_by_class[sensor_cls] = intermediate_dtype
-            return_dtype_by_class[sensor_cls] = return_dtype
-
-            if not sensor_cls.uses_manager_cache:
-                # Cameras own their multi-dtype `image_cache` and are read via `sensor.read()`. Register the dtype (so
-                # the paired intermediate cache exists for the empty per-step / reset slices) but contribute zero size,
-                # and assign an empty per-class slice. This avoids allocating a dead per-camera buffer and keeps
-                # `step()` / `reset()` slicing valid without special-casing them there.
-                cache_size_per_dtype.setdefault(intermediate_dtype, 0)
-                empty_at = cache_size_per_dtype[intermediate_dtype]
-                self._cache_slices_by_type[sensor_cls] = slice(empty_at, empty_at)
-                self._entity_slice_in_class[sensor_cls] = {}
-                self._max_history_by_class[sensor_cls] = 0
-                delay_depth_by_class[sensor_cls] = 1
-                continue
-
-            cache_size_per_dtype.setdefault(intermediate_dtype, 0)
-            cls_cache_start_idx = cache_size_per_dtype[intermediate_dtype]
+        ordered_classes = sorted(self._sensors_by_type.items(), key=lambda kv: not kv[0].uses_ring_pipeline)
+        for sensor_cls, sensors in ordered_classes:
+            if timeline_size_per_dtype is None and not sensor_cls.uses_ring_pipeline:
+                # First non-ring class: freeze the timeline-covered prefix width per dtype.
+                timeline_size_per_dtype = dict(cache_size_per_dtype)
+            cls_int_start: dict[torch.dtype, int] = {}  # per intermediate dtype: this class's start column (absolute)
             entity_offsets: dict[int, list[int]] = {}
             cls_offset = 0
             cls_max_history = 0
             cls_delay_depth = 1
             for sensor in sensors:
-                sensor._cache_idx = cache_size_per_dtype[intermediate_dtype]
-                cache_size_per_dtype[intermediate_dtype] += sensor._cache_size
+                sensor._cache_idx_by_dtype = {}
+                for dt, sz in sensor._intermediate_size_by_dtype.items():
+                    start = cache_size_per_dtype.get(dt, 0)
+                    cls_int_start.setdefault(dt, start)
+                    sensor._cache_idx_by_dtype[dt] = start
+                    cache_size_per_dtype[dt] = start + sz
+                    max_history_per_dtype.setdefault(dt, 0)
                 cls_delay_depth = max(cls_delay_depth, sensor._delay_ts + 1)
                 hist = sensor._options.history_length
                 if hist > 0:
-                    max_history_per_dtype[intermediate_dtype] = max(
-                        max_history_per_dtype.get(intermediate_dtype, 0), hist
-                    )
                     cls_max_history = max(cls_max_history, hist)
+                    if sensor_cls.uses_ring_pipeline:
+                        # Only ring-pipeline history grows the transform timeline ring; camera history is served by the
+                        # per-class return-space ring instead.
+                        for dt in sensor._intermediate_size_by_dtype:
+                            max_history_per_dtype[dt] = max(max_history_per_dtype[dt], hist)
                 eid = sensor._options.entity_idx
                 if eid in entity_offsets:
                     entity_offsets[eid][1] = cls_offset + sensor._cache_size
@@ -191,13 +193,16 @@ class SensorManager:
                     entity_offsets[eid] = [cls_offset, cls_offset + sensor._cache_size]
                 cls_offset += sensor._cache_size
 
-            cls_cache_end_idx = cache_size_per_dtype[intermediate_dtype]
-            self._cache_slices_by_type[sensor_cls] = slice(cls_cache_start_idx, cls_cache_end_idx)
+            self._cache_slices_by_type[sensor_cls] = {
+                dt: slice(cls_int_start[dt], cache_size_per_dtype[dt]) for dt in cls_int_start
+            }
             self._entity_slice_in_class[sensor_cls] = {
                 eid: slice(start, stop) for eid, (start, stop) in entity_offsets.items()
             }
             self._max_history_by_class[sensor_cls] = cls_max_history
             delay_depth_by_class[sensor_cls] = cls_delay_depth
+        if timeline_size_per_dtype is None:  # all classes are ring-pipeline
+            timeline_size_per_dtype = dict(cache_size_per_dtype)
 
         self._ground_truth_timeline_ring.clear()
         self._measured_timeline_ring.clear()
@@ -207,13 +212,6 @@ class SensorManager:
         self._measured_return_timeline_ring.clear()
         self._hist_idx_by_class.clear()
 
-        # Per-dtype flag: at least one class in this dtype uses the ring-based per-step pipeline. Drives allocation of
-        # the paired GT + measured timeline rings.
-        dtype_uses_rings: dict[torch.dtype, bool] = {}
-        for sensor_cls in self._sensors_by_type:
-            dtype = intermediate_dtype_by_class[sensor_cls]
-            dtype_uses_rings[dtype] = dtype_uses_rings.get(dtype, False) or sensor_cls.uses_ring_pipeline
-
         for dtype, total_cols in cache_size_per_dtype.items():
             cache_shape = (self._sim._B, total_cols)
             # Ground truth cache is stored transposed (cols, B) so that per-class row slices are C-contiguous, which is
@@ -222,51 +220,69 @@ class SensorManager:
             gt_cache_shape = (total_cols, self._sim._B)
             self._ground_truth_intermediate_cache[dtype] = torch.zeros(gt_cache_shape, dtype=dtype, device=gs.device)
             self._intermediate_cache[dtype] = torch.zeros(cache_shape, dtype=dtype, device=gs.device)
-            if dtype_uses_rings[dtype]:
-                # Timeline rings serve `_apply_transform` recurrence. Two slots cover the canonical one-step recurrence;
-                # the ring is grown to `max_history` when any sensor in the dtype requests history, so a multi-tap
-                # stateful filter inside `_apply_transform` can read deeper without keeping its own state.
+            timeline_cols = timeline_size_per_dtype.get(dtype, 0)
+            if timeline_cols > 0:
+                # Timeline rings serve `_apply_transform` recurrence and cover only the ring-pipeline column prefix.
+                # Two slots cover the canonical one-step recurrence; the ring is grown to `max_history` when any
+                # ring-pipeline sensor requests history so a multi-tap stateful filter can read deeper without state.
+                timeline_shape = (self._sim._B, timeline_cols)
                 ring_n = max(2, max_history_per_dtype.get(dtype, 0))
-                self._measured_timeline_ring[dtype] = TensorRingBuffer(ring_n, cache_shape, dtype=dtype)
+                self._measured_timeline_ring[dtype] = TensorRingBuffer(ring_n, timeline_shape, dtype=dtype)
                 self._ground_truth_timeline_ring[dtype] = TensorRingBuffer(
-                    ring_n, cache_shape, dtype=dtype, idx=self._measured_timeline_ring[dtype]._idx
+                    ring_n, timeline_shape, dtype=dtype, idx=self._measured_timeline_ring[dtype]._idx
                 )
 
-        # Per-class return-space caches + rings. The return-space ring is the single per-class buffer that records each
-        # step's post-`_post_process` snapshot; it is the source for delay sampling and history reads, and provides the
-        # `timeline` argument that stateful `_post_process` overrides see. Allocated whenever any sensor in the class
-        # has delay > 0, OR history > 0, OR the class overrides `_post_process`. Sized to fit the deepest demand. When
-        # no return-space ring is needed (no delay, no history, identity `_post_process`), the return cache is a
-        # zero-copy alias-view of the intermediate cache so per-step writes propagate without extra work.
+        # Per-(class, return-dtype) return-space caches + rings. The return-space ring records each step's post-
+        # `_post_process` snapshot; it is the source for delay sampling and history reads, and provides the `timeline`
+        # argument that stateful `_post_process` overrides see. Allocated whenever any sensor in the class has delay > 0,
+        # OR history > 0, OR the class overrides `_post_process`. When no ring is needed (no delay, no history, identity
+        # `_post_process`), the return cache is a zero-copy alias-view of the intermediate cache so per-step writes
+        # propagate without extra work. A multi-dtype class (a camera) gets one entry per dtype in each dict.
         for sensor_cls, sensors in self._sensors_by_type.items():
-            intermediate_dtype = intermediate_dtype_by_class[sensor_cls]
-            return_dtype = return_dtype_by_class[sensor_cls]
-            cls_slice = self._cache_slices_by_type[sensor_cls]
-            cls_size = cls_slice.stop - cls_slice.start
             cls_max_history = self._max_history_by_class[sensor_cls]
             cls_delay_depth = delay_depth_by_class[sensor_cls]
             pp_overridden = sensor_cls._post_process.__func__ is not Sensor._post_process.__func__
             needs_ring = cls_delay_depth > 1 or cls_max_history > 0 or pp_overridden
+
+            # Per return dtype: total class columns, and per-sensor relative start + delay layout. Return grouping
+            # mirrors the intermediate grouping in structure; they differ only in dtype label (e.g. ContactSensor:
+            # float intermediate -> bool return).
+            cls_ret_size: dict[torch.dtype, int] = {}
+            delay_layout: dict[torch.dtype, list[tuple[int, int]]] = {}
+            for sensor in sensors:
+                sensor._return_idx_by_dtype = {}
+                for dt, sz in sensor._return_size_by_dtype.items():
+                    start = cls_ret_size.get(dt, 0)
+                    sensor._return_idx_by_dtype[dt] = start
+                    cls_ret_size[dt] = start + sz
+                    delay_layout.setdefault(dt, []).append((sensor._idx, sz))
+            self._delay_layout_by_type[sensor_cls] = delay_layout
+
+            self._return_cache[sensor_cls] = {}
+            self._ground_truth_return_cache[sensor_cls] = {}
             if needs_ring:
                 ring_n = max(cls_delay_depth, cls_max_history, 2 if pp_overridden else 1)
-                ring_shape = (self._sim._B, cls_size)
-                self._ground_truth_return_timeline_ring[sensor_cls] = TensorRingBuffer(
-                    ring_n, ring_shape, dtype=return_dtype
-                )
-                self._measured_return_timeline_ring[sensor_cls] = TensorRingBuffer(
-                    ring_n, ring_shape, dtype=return_dtype, idx=self._ground_truth_return_timeline_ring[sensor_cls]._idx
-                )
-                self._return_cache[sensor_cls] = torch.zeros(
-                    (self._sim._B, cls_size), dtype=return_dtype, device=gs.device
-                )
-                self._ground_truth_return_cache[sensor_cls] = torch.zeros(
-                    (self._sim._B, cls_size), dtype=return_dtype, device=gs.device
-                )
+                self._ground_truth_return_timeline_ring[sensor_cls] = {}
+                self._measured_return_timeline_ring[sensor_cls] = {}
+                for dt, size in cls_ret_size.items():
+                    ring_shape = (self._sim._B, size)
+                    gt_ring = TensorRingBuffer(ring_n, ring_shape, dtype=dt)
+                    m_ring = TensorRingBuffer(ring_n, ring_shape, dtype=dt, idx=gt_ring._idx)
+                    self._ground_truth_return_timeline_ring[sensor_cls][dt] = gt_ring
+                    self._measured_return_timeline_ring[sensor_cls][dt] = m_ring
+                    self._return_cache[sensor_cls][dt] = torch.zeros((self._sim._B, size), dtype=dt, device=gs.device)
+                    self._ground_truth_return_cache[sensor_cls][dt] = torch.zeros(
+                        (self._sim._B, size), dtype=dt, device=gs.device
+                    )
             else:
-                self._return_cache[sensor_cls] = self._intermediate_cache[intermediate_dtype][:, cls_slice]
-                self._ground_truth_return_cache[sensor_cls] = self._ground_truth_intermediate_cache[intermediate_dtype][
-                    cls_slice, :
-                ].T
+                # Identity `_post_process` guarantees return dtype == intermediate dtype per field, so each return-dtype
+                # block aliases this class's slice of that dtype's intermediate buffer (same relative layout).
+                for dt in cls_ret_size:
+                    int_slice = self._cache_slices_by_type[sensor_cls][dt]
+                    self._return_cache[sensor_cls][dt] = self._intermediate_cache[dt][:, int_slice]
+                    self._ground_truth_return_cache[sensor_cls][dt] = self._ground_truth_intermediate_cache[dt][
+                        int_slice, :
+                    ].T
             if cls_max_history > 0:
                 self._hist_idx_by_class[sensor_cls] = torch.arange(cls_max_history, device=gs.device, dtype=torch.int32)
 
@@ -299,16 +315,21 @@ class SensorManager:
             if dtype in self._measured_timeline_ring:
                 self._measured_timeline_ring[dtype].buffer[:, envs_idx] = 0.0
 
-        # Reset per-class return caches. When the return cache is an alias-view of the intermediate cache the clear is
-        # redundant (the intermediate clear above already wrote zeros to the same memory) but harmless. Per-class
-        # return-space rings are always distinct buffers.
-        for sensor_cls in self._return_cache:
-            self._return_cache[sensor_cls][envs_idx] = 0
-            self._ground_truth_return_cache[sensor_cls][envs_idx] = 0
-        for ring in self._ground_truth_return_timeline_ring.values():
-            ring.buffer[:, envs_idx] = 0
-        for ring in self._measured_return_timeline_ring.values():
-            ring.buffer[:, envs_idx] = 0
+        # Reset per-(class, dtype) return caches. When the return cache is an alias-view of the intermediate cache the
+        # clear is redundant (the intermediate clear above already wrote zeros to the same memory) but harmless.
+        # Return-space rings are always distinct buffers.
+        for per_dtype in self._return_cache.values():
+            for cache in per_dtype.values():
+                cache[envs_idx] = 0
+        for per_dtype in self._ground_truth_return_cache.values():
+            for cache in per_dtype.values():
+                cache[envs_idx] = 0
+        for per_dtype in self._ground_truth_return_timeline_ring.values():
+            for ring in per_dtype.values():
+                ring.buffer[:, envs_idx] = 0
+        for per_dtype in self._measured_return_timeline_ring.values():
+            for ring in per_dtype.values():
+                ring.buffer[:, envs_idx] = 0
 
         # Reset shared contexts before the per-type sensor reset (a reset may change otherwise-static geometry, so the
         # context must rebuild before any sensor reads it again).
@@ -316,11 +337,15 @@ class SensorManager:
             context.reset(envs_idx)
 
         for sensor_cls, sensors in self._sensors_by_type.items():
-            dtype = sensor_cls._get_intermediate_dtype()
-            cache_slice = self._cache_slices_by_type[sensor_cls]
-            sensor_cls.reset(
-                self._sensors_metadata[sensor_cls], self._ground_truth_intermediate_cache[dtype][cache_slice], envs_idx
-            )
+            # `reset` receives the class's GT intermediate slice(s). Single-dtype classes (the only ones whose `reset`
+            # reads it, e.g. TemperatureGrid) get the sole slice tensor unchanged; multi-dtype classes (cameras, whose
+            # `reset` ignores it) get the per-dtype dict.
+            gt_by_dtype = {
+                dt: self._ground_truth_intermediate_cache[dt][sl]
+                for dt, sl in self._cache_slices_by_type[sensor_cls].items()
+            }
+            gt_arg = next(iter(gt_by_dtype.values())) if len(gt_by_dtype) == 1 else gt_by_dtype
+            sensor_cls.reset(self._sensors_metadata[sensor_cls], gt_arg, envs_idx)
 
     def step(self):
         # Timeline rings must rotate before `_update_shared_cache` because `_apply_transform` mutates `at(0)` of the
@@ -337,95 +362,138 @@ class SensorManager:
             context.update()
 
         for sensor_cls, sensors in self._sensors_by_type.items():
-            dtype = sensor_cls._get_intermediate_dtype()
-            cache_slice = self._cache_slices_by_type[sensor_cls]
-            ground_truth_slice = self._ground_truth_intermediate_cache[dtype][cache_slice]
-            intermediate = self._intermediate_cache[dtype][:, cache_slice]
-            ground_truth_data_timeline = (
-                self._ground_truth_timeline_ring[dtype][:, cache_slice]
-                if dtype in self._ground_truth_timeline_ring
-                else None
-            )
-            measured_data_timeline = (
-                self._measured_timeline_ring[dtype][:, cache_slice] if dtype in self._measured_timeline_ring else None
-            )
+            # Per-dtype views of this class's slice of each buffer it spans. A single-dtype class has one entry per
+            # dict (exactly the old scalars); a multi-dtype class (a camera) has one per dtype.
+            cls_int_slices = self._cache_slices_by_type[sensor_cls]
+            ground_truth_slices = {
+                dt: self._ground_truth_intermediate_cache[dt][sl] for dt, sl in cls_int_slices.items()
+            }
+            intermediates = {dt: self._intermediate_cache[dt][:, sl] for dt, sl in cls_int_slices.items()}
+            # Timeline rings exist only for ring-pipeline classes and cover only their column prefix, so non-ring
+            # classes (cameras) always get `None` here even when they share a dtype with a ring-pipeline sensor.
+            uses_rings = sensor_cls.uses_ring_pipeline
+            ground_truth_data_timelines = {
+                dt: (
+                    self._ground_truth_timeline_ring[dt][:, sl]
+                    if uses_rings and dt in self._ground_truth_timeline_ring
+                    else None
+                )
+                for dt, sl in cls_int_slices.items()
+            }
+            measured_data_timelines = {
+                dt: (
+                    self._measured_timeline_ring[dt][:, sl]
+                    if uses_rings and dt in self._measured_timeline_ring
+                    else None
+                )
+                for dt, sl in cls_int_slices.items()
+            }
             metadata = self._sensors_metadata[sensor_cls]
             sensor_cls._update_shared_cache(
                 self._shared_contexts.get(sensor_cls._shared_context_cls),
                 metadata,
-                ground_truth_slice,
-                ground_truth_data_timeline,
-                measured_data_timeline,
-                intermediate,
+                ground_truth_slices,
+                ground_truth_data_timelines,
+                measured_data_timelines,
+                intermediates,
             )
 
-            gt_return_ring = self._ground_truth_return_timeline_ring.get(sensor_cls)
-            if gt_return_ring is None:
+            gt_return_rings = self._ground_truth_return_timeline_ring.get(sensor_cls)
+            if gt_return_rings is None:
                 # No return-space ring: identity `_post_process`, no delay, no history. Return cache aliases
                 # intermediate (the per-step write inside `_update_shared_cache` is already visible to `read()`).
                 continue
-            measured_return_ring = self._measured_return_timeline_ring[sensor_cls]
+            measured_return_rings = self._measured_return_timeline_ring[sensor_cls]
+            delay_layout = self._delay_layout_by_type[sensor_cls]
+            pp_overridden = sensor_cls._post_process.__func__ is not Sensor._post_process.__func__
 
-            # Project both branches into the return-space ring slot 0. `_post_process` returns the post-cast tensor. The
-            # ring has not yet been rotated this step, so during the override `timeline.at(0)` is the previous step's
-            # post-output (the most recent valid value) and `timeline.at(1)`, `at(2)`, etc. are older. `is_measured`
-            # lets the override apply readout-stage contributions on only one branch.
-            measured_projected = sensor_cls._post_process(
-                metadata, intermediate, measured_return_ring, is_measured=True
-            )
-            gt_projected = sensor_cls._post_process(metadata, ground_truth_slice.T, gt_return_ring, is_measured=False)
+            for return_dtype, measured_return_ring in measured_return_rings.items():
+                gt_return_ring = gt_return_rings[return_dtype]
+                if pp_overridden:
+                    # `_post_process` overrides (e.g. ContactSensor float->bool) exist only on single-dtype classes, so
+                    # the sole intermediate slice is this class's whole working buffer; it may differ in dtype from the
+                    # return space. The ring has not yet rotated, so `timeline.at(0)` is the previous step's post-output.
+                    (intermediate,) = intermediates.values()
+                    (ground_truth_slice,) = ground_truth_slices.values()
+                    measured_projected = sensor_cls._post_process(
+                        metadata, intermediate, measured_return_ring, is_measured=True
+                    )
+                    gt_projected = sensor_cls._post_process(
+                        metadata, ground_truth_slice.T, gt_return_ring, is_measured=False
+                    )
+                else:
+                    # Identity projection: return dtype == intermediate dtype, so this dtype's intermediate slice is the
+                    # post-output directly (delay/history for cameras and other non-transforming sensors).
+                    measured_projected = intermediates[return_dtype]
+                    gt_projected = ground_truth_slices[return_dtype].T
 
-            # Rotate now, after `_post_process` reads finished and before writing this step's projections into slot 0.
-            # Only one rotate per pair since GT and measured return rings share idx.
-            gt_return_ring.rotate()
-            measured_return_ring.set(measured_projected)
-            gt_return_ring.set(gt_projected)
+                # Rotate now, after `_post_process` reads finished and before writing this step's projections into slot
+                # 0. Only one rotate per pair since GT and measured return rings share idx.
+                gt_return_ring.rotate()
+                measured_return_ring.set(measured_projected)
+                gt_return_ring.set(gt_projected)
 
-            # GT has no readout delay (delay is a measured-only effect), so the GT read is just the current ring slot.
-            self._ground_truth_return_cache[sensor_cls].copy_(gt_return_ring.at(0, copy=False))
-            # Measured: per-sensor delay + jitter sampling from the return-space ring into the per-class return cache.
-            # `_apply_delay` is an overrideable classmethod on `Sensor` whose default ZOH implementation is dtype-safe
-            # for any return space (bool, uint8, quantized float, ...).
-            sensor_cls._apply_delay(metadata, measured_return_ring, self._return_cache[sensor_cls])
+                # GT has no readout delay (delay is a measured-only effect), so the GT read is just the current slot.
+                self._ground_truth_return_cache[sensor_cls][return_dtype].copy_(gt_return_ring.at(0, copy=False))
+                # Measured: per-sensor delay + jitter sampling from the return-space ring into the per-class return
+                # cache. Default ZOH `_apply_delay` is dtype-safe for any return space (bool, uint8, quantized float).
+                sensor_cls._apply_delay(
+                    metadata,
+                    measured_return_ring,
+                    self._return_cache[sensor_cls][return_dtype],
+                    delay_layout[return_dtype],
+                )
 
     def draw_debug(self, context: "RasterizerContext"):
         for sensor in self.sensors:
             if sensor._options.draw_debug:
                 sensor._draw_debug(context)
 
-    def get_cloned_from_cache(self, sensor: "Sensor", is_ground_truth: bool = False) -> torch.Tensor:
+    def get_cloned_from_cache(self, sensor: "Sensor", is_ground_truth: bool = False) -> list[torch.Tensor]:
+        """
+        Return this sensor's data as a per-field list of ``(B, span)`` tensors (``span`` folds in history when enabled).
+
+        One tensor per return field, in field order; a multi-dtype sensor (a camera) reads each field from its own
+        dtype's return cache. `_get_formatted_data` reshapes and packs these into the sensor's return type. Cannot be a
+        single concatenated tensor because fields may differ in dtype.
+        """
         sensor_cls = type(sensor)
-        cls_slice = self._cache_slices_by_type[sensor_cls]
-        rel_start = sensor._cache_idx - cls_slice.start
         history_length = sensor._options.history_length
-
-        if history_length > 0:
-            sensor_hist = self._gather_history(sensor_cls, history_length, is_ground_truth)
-            sensor_slice = slice(rel_start, rel_start + sensor._cache_size)
-            sensor_hist = sensor_hist[:, :, sensor_slice]
-            blocks = [sensor_hist[..., rel_slice].flatten(1, 2) for rel_slice in sensor._cache_slices]
-            if len(blocks) == 1:
-                return blocks[0]
-            return torch.cat(blocks, dim=1)
-
-        # Pure view into the per-class return cache. Eager `_post_process` already populated it during step().
-        return_cache = (
+        return_caches = (
             self._ground_truth_return_cache[sensor_cls] if is_ground_truth else self._return_cache[sensor_cls]
         )
-        return return_cache[:, rel_start : rel_start + sensor._cache_size]
+        hist_by_dtype: dict[torch.dtype, torch.Tensor] = {}
 
-    def _gather_history(self, sensor_cls: type["Sensor"], history_length: int, is_ground_truth: bool) -> torch.Tensor:
-        # Gather the last `history_length` snapshots for the whole class into a fresh `(B, H, cls_size)` tensor. Always
-        # reads from the per-class return-space ring: it records the post-everything snapshot at each step, so history
-        # reads return the final measured (or GT) values observed in the past. The intermediate ring is in
-        # pre-hardware-imperfection space and would yield wrong history.
+        blocks: list[torch.Tensor] = []
+        for i, return_dtype in enumerate(sensor._field_dtypes):
+            rel_start = sensor._return_idx_by_dtype[return_dtype]
+            field_slice = sensor._field_return_slice[i]
+            col = slice(rel_start + field_slice.start, rel_start + field_slice.stop)
+            if history_length > 0:
+                if return_dtype not in hist_by_dtype:
+                    hist_by_dtype[return_dtype] = self._gather_history(
+                        sensor_cls, return_dtype, history_length, is_ground_truth
+                    )
+                blocks.append(hist_by_dtype[return_dtype][:, :, col].flatten(1, 2))
+            else:
+                # Pure view into the per-class return cache. Eager `_post_process` already populated it during step().
+                blocks.append(return_caches[return_dtype][:, col])
+        return blocks
+
+    def _gather_history(
+        self, sensor_cls: type["Sensor"], dtype: torch.dtype, history_length: int, is_ground_truth: bool
+    ) -> torch.Tensor:
+        # Gather the last `history_length` snapshots for the whole class (in dtype `dtype`) into a fresh
+        # `(B, H, cls_cols_in_dtype)` tensor. Always reads from the per-class return-space ring: it records the
+        # post-everything snapshot at each step, so history reads return the final measured (or GT) values observed in
+        # the past. The intermediate ring is in pre-hardware-imperfection space and would yield wrong history.
         hist_idx = self._hist_idx_by_class[sensor_cls][:history_length]
-        ring = (
+        rings = (
             self._ground_truth_return_timeline_ring[sensor_cls]
             if is_ground_truth
             else self._measured_return_timeline_ring[sensor_cls]
         )
-        return ring.at(hist_idx).transpose(0, 1)
+        return rings[dtype].at(hist_idx).transpose(0, 1)
 
     def read_sensors(
         self, entity_idx: int | None = None, envs_idx=None, is_ground_truth: bool = False
@@ -452,7 +520,8 @@ class SensorManager:
         dict[int, torch.Tensor]
             Mapping from sensor-type tag (`gs.sensors.types.<Name>`) to a tensor of shape
             (B, [history,] class_or_entity_cache_size). For sensors without history, the history
-            dimension is omitted.
+            dimension is omitted. Only ring-pipeline sensor classes are included; lazily-rendered sensors (cameras),
+            whose multi-modality output has no single-tensor representation, are read via `sensor.read()` instead.
         """
         # Sanitize envs_idx to a 1D tensor so fancy-indexing the batch axis always allocates a fresh tensor; this is
         # what gives the function its mutation-safe contract.
@@ -460,13 +529,20 @@ class SensorManager:
 
         result: dict[int, torch.Tensor] = {}
         for sensor_cls, sensors in self._sensors_by_type.items():
-            if not sensor_cls.uses_manager_cache:
-                # Cameras store multi-dtype images in their own cache; read them via `sensor.read()`, not here.
+            if not sensor_cls.uses_ring_pipeline:
+                # Cameras compute their output lazily on render (not through the eager per-step ring pipeline) and span
+                # several dtypes; the batched aggregate can't represent them. Read them via `sensor.read()`.
                 continue
+            return_caches = self._return_cache[sensor_cls]
+            # The batched aggregate is one tensor per class, so it only covers single-return-dtype classes (every
+            # current ring-pipeline sensor). A hypothetical multi-dtype ring sensor is skipped rather than crashing;
+            # read it via `sensor.read()`.
+            if len(return_caches) != 1:
+                continue
+            (return_dtype,) = return_caches.keys()
             entity_slice_map = self._entity_slice_in_class.get(sensor_cls, {})
             if entity_idx is None:
-                cls_slice = self._cache_slices_by_type[sensor_cls]
-                within_cls_slice = slice(0, cls_slice.stop - cls_slice.start)
+                within_cls_slice = slice(0, return_caches[return_dtype].shape[1])
             else:
                 eid = -1 if entity_idx < 0 else entity_idx
                 if eid not in entity_slice_map:
@@ -475,11 +551,13 @@ class SensorManager:
 
             cls_max_history = self._max_history_by_class[sensor_cls]
             if cls_max_history > 0:
-                sensor_hist = self._gather_history(sensor_cls, cls_max_history, is_ground_truth)
+                sensor_hist = self._gather_history(sensor_cls, return_dtype, cls_max_history, is_ground_truth)
                 tensor = sensor_hist[env_index, :, within_cls_slice]
             else:
                 return_cache = (
-                    self._ground_truth_return_cache[sensor_cls] if is_ground_truth else self._return_cache[sensor_cls]
+                    self._ground_truth_return_cache[sensor_cls][return_dtype]
+                    if is_ground_truth
+                    else return_caches[return_dtype]
                 )
                 tensor = return_cache[env_index, within_cls_slice]
 

--- a/genesis/engine/sensors/sensor_manager.py
+++ b/genesis/engine/sensors/sensor_manager.py
@@ -61,6 +61,8 @@ class SensorManager:
         self._max_history_by_class: dict[type["Sensor"], int] = {}
         # Per-(class, return-dtype) ordered `(global_sensor_idx, size_in_dtype)` list driving `_apply_delay`.
         self._delay_layout_by_type: dict[type["Sensor"], dict[torch.dtype, list[tuple[int, int]]]] = {}
+        # One-shot guard so `read_sensors` notes the camera/read_cameras split at most once per scene.
+        self._logged_camera_exclusion: bool = False
 
     def create_sensor(self, sensor_options: "SensorOptions") -> "Sensor":
         sensor_options.validate_scene(self._sim.scene)
@@ -499,7 +501,12 @@ class SensorManager:
         self, entity_idx: int | None = None, envs_idx=None, is_ground_truth: bool = False
     ) -> dict[int, torch.Tensor]:
         """
-        Read the latest data of every sensor class in scope as a single tensor per class.
+        Read the latest data of every **vector** sensor class in scope as a single tensor per class.
+
+        This is the batched reader for vector-shaped sensors (IMU, contact, raycaster, ...): one flat tensor per
+        sensor type. Camera / image sensors are NOT included here - their multi-modality image output has no
+        single-tensor representation, and reading them would force a render on every call. Read cameras individually
+        via `camera.read()`, or all at once via `scene.read_cameras()`.
 
         Always returns a fresh tensor per class, independent of the internal sensor storage; the caller is free to
         mutate the result.
@@ -507,7 +514,7 @@ class SensorManager:
         Parameters
         ----------
         entity_idx : int | None
-            - None (default): include every sensor in the scene.
+            - None (default): include every vector sensor in the scene.
             - k >= 0: include only sensors whose `entity_idx == k`.
             - -1: include only static sensors (those not attached to any entity).
         envs_idx : array-like | int | slice | None
@@ -520,18 +527,27 @@ class SensorManager:
         dict[int, torch.Tensor]
             Mapping from sensor-type tag (`gs.sensors.types.<Name>`) to a tensor of shape
             (B, [history,] class_or_entity_cache_size). For sensors without history, the history
-            dimension is omitted. Only ring-pipeline sensor classes are included; lazily-rendered sensors (cameras),
-            whose multi-modality output has no single-tensor representation, are read via `sensor.read()` instead.
+            dimension is omitted. Camera sensors are excluded (see `read_cameras`).
         """
         # Sanitize envs_idx to a 1D tensor so fancy-indexing the batch axis always allocates a fresh tensor; this is
         # what gives the function its mutation-safe contract.
         env_index = self._sim._scene._sanitize_envs_idx(envs_idx)
 
+        # Surface the camera/vector split once so a user with cameras in the scene isn't confused by their absence.
+        if not self._logged_camera_exclusion:
+            cameras = self.camera_sensors
+            if cameras:
+                gs.logger.info(
+                    f"`read_sensors()` returns vector sensors only; {len(cameras)} camera sensor(s) are excluded. "
+                    "Read them via `camera.read()` or all at once via `scene.read_cameras()`."
+                )
+            self._logged_camera_exclusion = True
+
         result: dict[int, torch.Tensor] = {}
         for sensor_cls, sensors in self._sensors_by_type.items():
             if not sensor_cls.uses_ring_pipeline:
                 # Cameras compute their output lazily on render (not through the eager per-step ring pipeline) and span
-                # several dtypes; the batched aggregate can't represent them. Read them via `sensor.read()`.
+                # several dtypes; the batched aggregate can't represent them. Read them via `read_cameras`.
                 continue
             return_caches = self._return_cache[sensor_cls]
             # The batched aggregate is one tensor per class, so it only covers single-return-dtype classes (every
@@ -577,6 +593,44 @@ class SensorManager:
             for sensor in sensor_list
             if sensor._options.entity_idx == target_eid
         )
+
+    @property
+    def camera_sensors(self) -> "gs.List[Sensor]":
+        """The camera sensors in the scene - the ones excluded from `read_sensors` and read via `read_cameras`."""
+        # Local import avoids a module-level cycle (camera -> base_sensor -> sensor_manager) and defers the heavy vis
+        # imports that `camera` pulls in.
+        from .camera import BaseCameraSensor
+
+        return gs.List(sensor for sensor in self.sensors if isinstance(sensor, BaseCameraSensor))
+
+    def read_cameras(self, entity_idx: int | None = None, envs_idx=None):
+        """
+        Render and read every camera sensor in scope, returned per camera.
+
+        Complements `read_sensors` (which covers vector sensors): each camera is read via its own `read()`, so the
+        result is one `CameraReturnType` (`.rgb` / `.depth` / `.segmentation` / `.normal`) per camera. Rendering
+        happens here, so this is only paid when explicitly called.
+
+        Parameters
+        ----------
+        entity_idx : int | None
+            - None (default): every camera in the scene.
+            - k >= 0: only cameras whose `entity_idx == k`.
+            - -1: only static cameras (not attached to any entity).
+        envs_idx : array-like | int | slice | None
+            Environment selection passed through to each `camera.read()`.
+
+        Returns
+        -------
+        dict[Sensor, CameraReturnType]
+            Mapping from each camera sensor to its rendered modalities.
+        """
+        target_eid = None if entity_idx is None else (-1 if entity_idx < 0 else entity_idx)
+        return {
+            camera: camera.read(envs_idx)
+            for camera in self.camera_sensors
+            if target_eid is None or camera._options.entity_idx == target_eid
+        }
 
     @property
     def sensors(self):

--- a/genesis/options/sensors/camera.py
+++ b/genesis/options/sensors/camera.py
@@ -78,11 +78,6 @@ class BaseCameraOptions(KinematicSensorOptionsMixin[SensorT]):
     render_normal: StrictBool = False
 
     def model_post_init(self, context: Any) -> None:
-        if self.history_length > 0:
-            gs.raise_exception(
-                "Camera sensors do not support `history_length`. The camera read path renders lazily on read() "
-                "and bypasses the shared sensor cache that backs the history buffer."
-            )
         if not (self.render_rgb or self.render_depth or self.render_segmentation or self.render_normal):
             gs.raise_exception(
                 "Camera sensor has no enabled modalities. Enable at least one of "

--- a/genesis/options/sensors/camera.py
+++ b/genesis/options/sensors/camera.py
@@ -50,6 +50,19 @@ class BaseCameraOptions(KinematicSensorOptionsMixin[SensorT]):
         The global entity index of the RigidEntity to which this sensor is attached. -1 or None for static sensors.
     link_idx_local : int, optional
         The local index of the RigidLink of the RigidEntity to which this sensor is attached.
+    render_rgb : bool
+        Whether the sensor produces an RGB image. Read from ``sensor.read().rgb`` as ``uint8`` of shape (H, W, 3).
+        Default is True.
+    render_depth : bool
+        Whether the sensor produces a depth image. Read from ``sensor.read().depth`` as ``float32`` of shape (H, W).
+        This is the *rendered* (planar Z) depth from the render backend, distinct from the raycast/Euclidean-range
+        depth produced by ``gs.sensors.DepthCamera``. Default is False.
+    render_segmentation : bool
+        Whether the sensor produces a segmentation map. Read from ``sensor.read().segmentation`` as ``int32`` of shape
+        (H, W), holding per-pixel object/link/geom indices (see ``VisOptions.segmentation_level``). Default is False.
+    render_normal : bool
+        Whether the sensor produces a surface-normal image. Read from ``sensor.read().normal`` as ``float32`` of shape
+        (H, W, 3). Default is False.
     """
 
     res: PositiveVec2IType = (512, 512)
@@ -59,12 +72,21 @@ class BaseCameraOptions(KinematicSensorOptionsMixin[SensorT]):
     fov: ValidFloat = Field(default=60.0, gt=0, lt=180)
     lights: list[dict[str, Any]] = []
     offset_T: Matrix4x4Type | None = None
+    render_rgb: StrictBool = True
+    render_depth: StrictBool = False
+    render_segmentation: StrictBool = False
+    render_normal: StrictBool = False
 
     def model_post_init(self, context: Any) -> None:
         if self.history_length > 0:
             gs.raise_exception(
                 "Camera sensors do not support `history_length`. The camera read path renders lazily on read() "
                 "and bypasses the shared sensor cache that backs the history buffer."
+            )
+        if not (self.render_rgb or self.render_depth or self.render_segmentation or self.render_normal):
+            gs.raise_exception(
+                "Camera sensor has no enabled modalities. Enable at least one of "
+                "`render_rgb`, `render_depth`, `render_segmentation`, `render_normal`."
             )
 
 

--- a/genesis/vis/camera.py
+++ b/genesis/vis/camera.py
@@ -2,6 +2,7 @@ import inspect
 import os
 import time
 from functools import cached_property
+from typing import Protocol, runtime_checkable
 
 import numpy as np
 import torch
@@ -14,6 +15,32 @@ from genesis.utils.misc import tensor_to_array
 from genesis.utils.image_exporter import as_grayscale_image
 
 
+@runtime_checkable
+class CameraBackendProvider(Protocol):
+    """
+    The rendering context a `Camera` builds and renders against.
+
+    A `Camera` is decoupled from the full `Visualizer`: it only reaches for this closed set of members, so it can be
+    driven either by the interactive `Visualizer` (which satisfies this protocol) or by a lightweight standalone
+    provider used for headless / sensor rendering. All members are plain attributes/methods - no `getattr` probing.
+    """
+
+    # Rendering backends; exactly one path is active (batch renderer, or rasterizer +/- raytracer).
+    rasterizer: object
+    raytracer: object
+    batch_renderer: object
+    # `RasterizerContext` exposing `rendered_envs_idx` and `env_separate_rigid`.
+    context: object
+    # The `Scene` exposing `n_envs`, `envs_offset`, `_t`, and `_sanitize_envs_idx`.
+    scene: object
+    # Whether an on-screen display is available (drives the optional GUI preview in `render`).
+    has_display: bool
+
+    def colorize_seg_idxc_arr(self, seg_idxc_arr):
+        """Map a per-pixel segmentation index array to an RGB color image."""
+        ...
+
+
 class Camera(RBC):
     """
     A camera which can be used to render RGB, depth, and segmentation images.
@@ -21,8 +48,9 @@ class Camera(RBC):
 
     Parameters
     ----------
-    visualizer : genesis.Visualizer
-        The visualizer object that the camera is associated with.
+    backend : CameraBackendProvider
+        The rendering context the camera builds and renders against. The interactive `Visualizer` satisfies this
+        protocol; a lightweight standalone provider is used for headless / sensor rendering.
     idx : int
         The index of the camera.
     model : str
@@ -69,7 +97,7 @@ class Camera(RBC):
 
     def __init__(
         self,
-        visualizer,
+        backend,
         idx=0,
         model="pinhole",  # pinhole or thinlens
         res=(320, 320),
@@ -107,7 +135,7 @@ class Camera(RBC):
         if transform is not None:
             self._initial_transform = torch.as_tensor(transform, dtype=gs.tc_float, device=gs.device)
         self._aspect_ratio = self._res[0] / self._res[1]  # width / height
-        self._visualizer = visualizer
+        self._backend: CameraBackendProvider = backend
         self._debug = debug
 
         self._is_built = False
@@ -139,13 +167,13 @@ class Camera(RBC):
             self._focus_dist = np.linalg.norm(np.asarray(lookat) - np.asarray(pos))
 
     def build(self):
-        self._rasterizer = self._visualizer.rasterizer
+        self._rasterizer = self._backend.rasterizer
         if not self._debug:
-            self._raytracer = self._visualizer.raytracer
-            self._batch_renderer = self._visualizer.batch_renderer
+            self._raytracer = self._backend.raytracer
+            self._batch_renderer = self._backend.batch_renderer
 
         if self._batch_renderer is not None:
-            self._is_batched = self._visualizer.scene.n_envs > 0
+            self._is_batched = self._backend.scene.n_envs > 0
             if self._env_idx is not None:
                 gs.raise_exception("Binding a camera to one specific environment index not supported by BatchRender.")
         else:
@@ -154,23 +182,23 @@ class Camera(RBC):
                 self._is_batched = False
                 self._raytracer.add_camera(self)
             else:
-                self._is_batched = self._visualizer.scene.n_envs > 0 and self._visualizer._context.env_separate_rigid
-            if self._visualizer.scene.n_envs > 0:
+                self._is_batched = self._backend.scene.n_envs > 0 and self._backend.context.env_separate_rigid
+            if self._backend.scene.n_envs > 0:
                 if self._env_idx is None:
                     if not self._is_batched:
-                        self._env_idx = int(self._visualizer._context.rendered_envs_idx[0])
-                        if self._visualizer.scene.n_envs > 1:
+                        self._env_idx = int(self._backend.context.rendered_envs_idx[0])
+                        if self._backend.scene.n_envs > 1:
                             gs.logger.info(
                                 "Raytracer and Rasterizer requires binding to the camera with a specific environment "
                                 "index. Defaulting to 'rendered_envs_idx[0]'. Please specify 'env_idx' if necessary."
                             )
-                elif self._env_idx not in self._visualizer._context.rendered_envs_idx:
+                elif self._env_idx not in self._backend.context.rendered_envs_idx:
                     gs.raise_exception("Environment index bound to the camera not in 'VisOptions.rendered_envs_idx'.")
             else:
                 assert self._env_idx is None
 
         if self._is_batched and self._env_idx is None:
-            batch_size = (len(self._visualizer._context.rendered_envs_idx),)
+            batch_size = (len(self._backend.context.rendered_envs_idx),)
         else:
             batch_size = ()
         self._pos = torch.empty((*batch_size, 3), dtype=gs.tc_float, device=gs.device)
@@ -180,9 +208,9 @@ class Camera(RBC):
         self._quat = torch.empty((*batch_size, 4), dtype=gs.tc_float, device=gs.device)
 
         if self._is_batched and self._env_idx is None:
-            envs_offset = self._visualizer._scene.envs_offset[self._visualizer._context.rendered_envs_idx]
+            envs_offset = self._backend.scene.envs_offset[self._backend.context.rendered_envs_idx]
         else:
-            envs_offset = self._visualizer._scene.envs_offset[self._env_idx or 0]
+            envs_offset = self._backend.scene.envs_offset[self._env_idx or 0]
         self._envs_offset = torch.as_tensor(envs_offset, dtype=gs.tc_float, device=gs.device)
 
         # Must consider the building process done before setting initial pose, otherwise it will fail
@@ -242,8 +270,8 @@ class Camera(RBC):
             gs.raise_exception("Camera not attached to any rigid link.")
 
         if self._is_batched and self._env_idx is None:
-            link_pos = self._attached_link.get_pos(self._visualizer._context.rendered_envs_idx, relative=False)
-            link_quat = self._attached_link.get_quat(self._visualizer._context.rendered_envs_idx, relative=False)
+            link_pos = self._attached_link.get_pos(self._backend.context.rendered_envs_idx, relative=False)
+            link_quat = self._attached_link.get_quat(self._backend.context.rendered_envs_idx, relative=False)
         else:
             link_pos = self._attached_link.get_pos(self._env_idx, relative=False).reshape((-1,))
             link_quat = self._attached_link.get_quat(self._env_idx, relative=False).reshape((-1,))
@@ -274,7 +302,7 @@ class Camera(RBC):
 
         if self._is_built:
             if self._is_batched and self._env_idx is None:
-                entity_pos = entity.get_pos(self._visualizer._context.rendered_envs_idx, relative=False)
+                entity_pos = entity.get_pos(self._backend.context.rendered_envs_idx, relative=False)
             else:
                 entity_pos = entity.get_pos(self._env_idx, relative=False).reshape((-1,))
             pos_rel = self._pos - entity_pos
@@ -322,7 +350,7 @@ class Camera(RBC):
 
         # Query entity and relative camera positions
         if self._is_batched and self._env_idx is None:
-            entity_pos = self._followed_entity.get_pos(self._visualizer._context.rendered_envs_idx, relative=False)
+            entity_pos = self._followed_entity.get_pos(self._backend.context.rendered_envs_idx, relative=False)
         else:
             entity_pos = self._followed_entity.get_pos(self._env_idx, relative=False).reshape((-1,))
         follow_pos_rel = self._follow_pos_rel
@@ -363,7 +391,7 @@ class Camera(RBC):
         """
         Render the camera view with batch renderer.
         """
-        assert self._visualizer._batch_renderer is not None
+        assert self._backend.batch_renderer is not None
 
         # Render all cameras at once no matter what
         buffers = list(self._batch_renderer.render(rgb, depth, segmentation, normal, antialiasing, force_render))
@@ -430,7 +458,7 @@ class Camera(RBC):
             The rendered surface normal(s).
         """
         # Enforce RGB rendering if recording is enabled and the current frame is missing
-        is_recording = self._in_recording and self._recorded_t_prev != self._visualizer.scene._t
+        is_recording = self._in_recording and self._recorded_t_prev != self._backend.scene._t
         rgb_ = rgb or is_recording
 
         # Render the current frame
@@ -457,12 +485,12 @@ class Camera(RBC):
 
         # Colorize the segmentation map is necessary
         if seg_idxc_arr is not None:
-            if colorize_seg or (self._GUI and self._visualizer.has_display):
-                seg_color_arr = self._visualizer.colorize_seg_idxc_arr(seg_idxc_arr)
+            if colorize_seg or (self._GUI and self._backend.has_display):
+                seg_color_arr = self._backend.colorize_seg_idxc_arr(seg_idxc_arr)
             seg_arr = seg_color_arr if colorize_seg else seg_idxc_arr
 
         # Display images if requested and supported
-        if self._GUI and self._visualizer.has_display:
+        if self._GUI and self._backend.has_display:
             # Postpone import of OpenCV at runtime to reduce hard system dependencies
             import cv2
 
@@ -470,7 +498,7 @@ class Camera(RBC):
             if self._debug:
                 title += " (debug)"
             if self._is_batched:
-                rendered_envs_idx = self._visualizer._context.rendered_envs_idx
+                rendered_envs_idx = self._backend.context.rendered_envs_idx
                 title += f" - Environments {rendered_envs_idx}"
             for img_type, (flag, buffer) in enumerate(
                 ((rgb, rgb_arr), (depth, depth_arr), (segmentation, seg_color_arr), (normal, normal_arr))
@@ -488,11 +516,11 @@ class Camera(RBC):
 
         # Store the current frame for video recording
         if is_recording:
-            if not (self._recorded_t_prev < 0 or self._recorded_t_prev == self._visualizer.scene._t - 1):
+            if not (self._recorded_t_prev < 0 or self._recorded_t_prev == self._backend.scene._t - 1):
                 gs.raise_exception(
                     "Missing frames in recording. Please call 'camera.render()' after 'every scene.step()'."
                 )
-            self._recorded_t_prev == self._visualizer.scene._t
+            self._recorded_t_prev == self._backend.scene._t
             rgb_frame = tensor_to_array(rgb_arr)
             self._recorded_imgs.append(rgb_frame)
 
@@ -612,10 +640,10 @@ class Camera(RBC):
         if self._is_batched:
             if envs_idx is None:
                 envs_idx = (self._env_idx,) if self._env_idx is not None else ()
-                n_envs = len(self._visualizer._context.rendered_envs_idx)
+                n_envs = len(self._backend.context.rendered_envs_idx)
             else:
-                envs_idx = self._visualizer._scene._sanitize_envs_idx(envs_idx)
-                if set(envs_idx).issubset(self._visualizer._context.rendered_envs_idx):
+                envs_idx = self._backend.scene._sanitize_envs_idx(envs_idx)
+                if set(envs_idx).issubset(self._backend.context.rendered_envs_idx):
                     gs.raise_exception("Environment index not in 'VisOptions.rendered_envs_idx'.")
                 n_envs = len(envs_idx)
         else:
@@ -726,7 +754,7 @@ class Camera(RBC):
             )
 
         if self._is_batched:
-            for env_idx in self._visualizer._context.rendered_envs_idx:
+            for env_idx in self._backend.context.rendered_envs_idx:
                 env_imgs = [imgs[env_idx] for imgs in self._recorded_imgs]
                 env_name, env_ext = os.path.splitext(save_to_filename)
                 gs.tools.animate(env_imgs, f"{env_name}_{env_idx}{env_ext}", fps)
@@ -742,7 +770,7 @@ class Camera(RBC):
         assert self._env_idx is None or envs_idx is None
         envs_idx = () if envs_idx is None else envs_idx
         pos = self._pos[envs_idx]
-        if self._batch_renderer is None and not self._visualizer._context.env_separate_rigid:
+        if self._batch_renderer is None and not self._backend.context.env_separate_rigid:
             pos = pos + self._envs_offset[envs_idx]
         return pos
 
@@ -751,7 +779,7 @@ class Camera(RBC):
         assert self._env_idx is None or envs_idx is None
         envs_idx = () if envs_idx is None else envs_idx
         lookat = self._lookat[envs_idx]
-        if self._batch_renderer is None and not self._visualizer._context.env_separate_rigid:
+        if self._batch_renderer is None and not self._backend.context.env_separate_rigid:
             lookat = lookat + self._envs_offset[envs_idx]
         return lookat
 
@@ -774,7 +802,7 @@ class Camera(RBC):
         assert self._env_idx is None or envs_idx is None
         envs_idx = () if envs_idx is None else envs_idx
         transform = self._transform[envs_idx]
-        if self._batch_renderer is None and not self._visualizer._context.env_separate_rigid:
+        if self._batch_renderer is None and not self._backend.context.env_separate_rigid:
             transform = transform.clone()
             transform[..., :3, 3] += self._envs_offset[envs_idx]
         return transform

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -327,7 +327,7 @@ def test_destroy_after_failed_camera_build(monkeypatch, raise_before_build):
     shared_metadata = camera._shared_metadata
 
     # Inject a bug either at build entry (no metadata population) or after the original build
-    # has populated renderer / context / sensors / image_cache.
+    # has populated renderer / context / sensors.
     original_build = RasterizerCameraSensor.build
 
     def buggy_build(self):
@@ -346,7 +346,6 @@ def test_destroy_after_failed_camera_build(monkeypatch, raise_before_build):
         assert shared_metadata.renderer is not None
         assert shared_metadata.context is not None
         assert shared_metadata.sensors is not None
-        assert shared_metadata.image_cache is not None
 
     # Track shared_metadata.destroy() invocations via instance-level shadow. Assigning to the
     # instance __dict__ takes precedence over class-level lookup for this instance only, so
@@ -369,7 +368,6 @@ def test_destroy_after_failed_camera_build(monkeypatch, raise_before_build):
     assert shared_metadata.renderer is None
     assert shared_metadata.context is None
     assert shared_metadata.sensors is None
-    assert shared_metadata.image_cache is None
 
 
 @pytest.mark.required

--- a/tests/test_sensor_camera.py
+++ b/tests/test_sensor_camera.py
@@ -170,7 +170,7 @@ def test_rasterizer_non_batched(n_envs, show_viewer):
     def _get_camera_world_pos(sensor):
         renderer = sensor._shared_metadata.renderer
         context = sensor._shared_metadata.context
-        node = renderer._camera_nodes[sensor._idx]
+        node = renderer._camera_nodes[sensor.camera.uid]
         pose = context._scene.get_pose(node)
         if pose.ndim == 3:
             pose = pose[0]
@@ -321,7 +321,7 @@ def test_rasterizer_attached_batched(show_viewer, png_snapshot, tol):
     link_T = trans_quat_to_T(sphere_pos, sphere_quat)
     expected_T = link_T @ offset_T
 
-    camera_node = camera._shared_metadata.renderer._camera_nodes[camera._idx]
+    camera_node = camera._shared_metadata.renderer._camera_nodes[camera.camera.uid]
     actual_pose = camera._shared_metadata.context._scene.get_pose(camera_node)
     assert_allclose(actual_pose, expected_T, tol=tol)
 
@@ -803,6 +803,46 @@ def test_camera_coexists_with_ring_pipeline_sensor():
     assert gs.sensors.types.IMU in bulk  # ring-pipeline sensor is aggregated
     assert gs.sensors.types.RasterizerCameraOptions not in bulk  # camera is read via camera.read()
     assert imu.read() is not None
+
+
+@pytest.mark.required
+def test_camera_sensor_intrinsics_extrinsics():
+    # The sensor delegates camera matrices to its owned vis.Camera; they must match a scene.add_camera of the same
+    # pose/params (intrinsics/projection are exact; extrinsics matches the shared static world pose).
+    CAM_RES = (128, 96)
+    W, H = CAM_RES
+    common = dict(res=CAM_RES, pos=(3.0, 0.0, 2.0), lookat=(0.0, 0.0, 1.0), up=(0.0, 0.0, 1.0), fov=60.0)
+    scene = gs.Scene(show_viewer=False)
+    scene.add_entity(morph=gs.morphs.Plane())
+    sensor = scene.add_sensor(gs.sensors.RasterizerCameraOptions(near=0.1, far=100.0, **common))
+    ref = scene.add_camera(near=0.1, far=100.0, **common)
+    scene.build(n_envs=0)
+    sensor._shared_metadata.context.shadow = False
+    scene.step()
+    sensor.read()
+
+    assert_allclose(sensor.intrinsics, ref.intrinsics, atol=1e-6)
+    assert_allclose(sensor.projection_matrix, ref.projection_matrix, atol=1e-6)
+    assert_allclose(sensor.extrinsics, ref.extrinsics, atol=1e-4)
+    assert_allclose(sensor.cx, W / 2, atol=1e-6)
+    assert_allclose(sensor.cy, H / 2, atol=1e-6)
+
+
+@pytest.mark.slow
+@pytest.mark.required
+def test_camera_sensor_set_pose_moves_detached():
+    # A detached sensor camera can be re-posed at runtime via the delegated set_pose; the next read re-renders.
+    scene, camera = _modality_scene((64, 48))
+    scene.build(n_envs=0)
+    camera._shared_metadata.context.shadow = False
+    scene.step()
+    frame_a = camera.read().rgb.clone()
+    pos_a = camera.get_pos().clone()
+
+    camera.set_pose(pos=(0.0, 3.0, 2.0), lookat=(0.0, 0.0, 1.0), up=(0.0, 0.0, 1.0))
+    assert (camera.get_pos() != pos_a).any()
+    frame_b = camera.read().rgb
+    assert (frame_a != frame_b).any(), "re-posing a detached camera must change the rendered frame"
 
 
 @pytest.mark.slow

--- a/tests/test_sensor_camera.py
+++ b/tests/test_sensor_camera.py
@@ -771,6 +771,113 @@ def test_rasterizer_modality_defaults_rgb_only():
     assert scene.read_sensors() == {}
 
 
+@pytest.mark.slow
+@pytest.mark.required
+def test_camera_coexists_with_ring_pipeline_sensor():
+    # A float32 depth camera (non-ring) shares the float32 buffer with an IMU (ring-pipeline). The camera columns must
+    # stay out of the IMU's transform timeline ring, both sensors must read correctly, and read_sensors() must return
+    # the IMU but not the camera.
+    scene = gs.Scene(show_viewer=False)
+    scene.add_entity(morph=gs.morphs.Plane())
+    box = scene.add_entity(morph=gs.morphs.Box(size=(0.2, 0.2, 0.2), pos=(0.0, 0.0, 1.0)))
+    imu = scene.add_sensor(gs.sensors.IMU(entity_idx=box.idx))
+    camera = scene.add_sensor(
+        gs.sensors.RasterizerCameraOptions(
+            res=(48, 48),
+            pos=(2.0, 0.0, 1.0),
+            lookat=(0.0, 0.0, 1.0),
+            up=(0.0, 0.0, 1.0),
+            render_rgb=False,
+            render_depth=True,
+        )
+    )
+    scene.build(n_envs=0)
+    camera._shared_metadata.context.shadow = False
+    scene.step()
+
+    depth = camera.read().depth
+    assert depth.shape == (48, 48) and depth.dtype == torch.float32
+    assert torch.isfinite(depth).any()
+
+    bulk = scene.read_sensors()
+    assert gs.sensors.types.IMU in bulk  # ring-pipeline sensor is aggregated
+    assert gs.sensors.types.RasterizerCameraOptions not in bulk  # camera is read via camera.read()
+    assert imu.read() is not None
+
+
+@pytest.mark.slow
+@pytest.mark.required
+def test_camera_read_after_reset_rerenders():
+    # Camera storage now lives in the shared manager cache, which reset() zeroes; a read at the same timestep as a
+    # preceding reset must re-render rather than return the zeroed cache.
+    scene, camera = _modality_scene((64, 48))
+    scene.build(n_envs=0)
+    camera._shared_metadata.context.shadow = False
+    scene.step()
+    before = camera.read().rgb.clone()
+    assert before.float().std() > 1.0  # a real rendered frame, not a blank buffer
+
+    scene.reset()
+    after = camera.read().rgb
+    assert after.float().std() > 1.0, "read after reset returned a blank/zeroed frame instead of re-rendering"
+
+
+@pytest.mark.slow
+@pytest.mark.required
+@pytest.mark.parametrize("n_envs", [0, 2])
+def test_camera_history(n_envs):
+    CAM_RES = (64, 48)
+    W, H = CAM_RES
+    scene, camera = _modality_scene(CAM_RES, render_depth=True, history_length=3)
+    scene.build(n_envs=n_envs)
+    camera._shared_metadata.context.shadow = False
+    sphere = scene.entities[1]
+
+    # Distinct sphere heights per step so consecutive snapshots differ. A read between steps must not disturb the
+    # per-step capture, so interleave a read to guard the eager-render dedup.
+    for z in (2.0, 1.4, 0.8, 0.6):
+        sphere.set_pos([0.0, 0.0, z] if n_envs == 0 else [[0.0, 0.0, z]] * n_envs)
+        scene.step()
+        camera.read()
+
+    data = camera.read()
+    batch = () if n_envs == 0 else (n_envs,)
+    # History adds a leading dimension of length 3 in front of the modality shape.
+    assert data.rgb.shape == (*batch, 3, H, W, 3) and data.rgb.dtype == torch.uint8
+    assert data.depth.shape == (*batch, 3, H, W) and data.depth.dtype == torch.float32
+
+    depth_hist = data.depth if n_envs == 0 else data.depth[0]  # (3, H, W), newest-first
+    assert (depth_hist[0] != depth_hist[1]).any()
+    assert (depth_hist[1] != depth_hist[2]).any()
+
+
+@pytest.mark.slow
+@pytest.mark.required
+def test_camera_delay():
+    scene, camera = _modality_scene((64, 48), delay=0.02)  # 2 steps at the default dt=0.01
+    scene.build(n_envs=0)
+    camera._shared_metadata.context.shadow = False
+    assert camera._delay_ts == 2
+    sphere = scene.entities[1]
+
+    # Step-1 frame (undelayed ground truth) is what a 2-step delayed read must reproduce two steps later. Reading each
+    # step exercises the interleaved read/step path that a naive scene.t dedup would corrupt.
+    sphere.set_pos([0.0, 0.0, 2.0])
+    scene.step()
+    frame_step1 = camera.read_ground_truth().rgb.clone()
+
+    sphere.set_pos([0.0, 0.0, 1.2])
+    scene.step()
+    camera.read()
+    sphere.set_pos([0.0, 0.0, 0.6])
+    scene.step()
+
+    delayed = camera.read().rgb  # measured, delayed by 2 steps
+    current = camera.read_ground_truth().rgb  # undelayed, current step
+    assert_equal(delayed, frame_step1)  # ZOH reproduces the exact frame from 2 steps ago
+    assert (delayed != current).any()  # the delay actually shifted the observed frame
+
+
 @pytest.mark.required
 def test_camera_modalities_require_at_least_one():
     with pytest.raises(gs.GenesisException, match="at least one"):
@@ -829,9 +936,7 @@ def test_batch_renderer_modalities(n_envs):
         )
     )
     # A second camera in the same batch requesting only depth exercises the per-sensor modality union path.
-    cam_depth = scene.add_sensor(
-        gs.sensors.BatchRendererCameraOptions(**common, render_rgb=False, render_depth=True)
-    )
+    cam_depth = scene.add_sensor(gs.sensors.BatchRendererCameraOptions(**common, render_rgb=False, render_depth=True))
     scene.build(n_envs=n_envs)
     scene.step()
 

--- a/tests/test_sensor_camera.py
+++ b/tests/test_sensor_camera.py
@@ -699,3 +699,149 @@ def test_camera_lookat_entity(show_viewer, png_snapshot):
             if sys.platform == "darwin" and scene.visualizer.is_software:
                 pytest.xfail("Flaky on MacOS with Apple Software Renderer. Nothing but the background was rendered.")
             raise
+
+
+def _modality_scene(res, **cam_kwargs):
+    """A small scene with several distinct entities and one rasterizer camera; returns (scene, camera)."""
+    scene = gs.Scene(show_viewer=False)
+    scene.add_entity(morph=gs.morphs.Plane())
+    scene.add_entity(
+        morph=gs.morphs.Sphere(radius=0.5, pos=(0.0, 0.0, 2.0)),
+        surface=gs.surfaces.Smooth(color=(1.0, 0.5, 0.5)),
+    )
+    scene.add_entity(
+        morph=gs.morphs.Box(size=(0.3, 0.3, 0.3), pos=(1.0, 1.0, 1.0)),
+        surface=gs.surfaces.Rough(color=(0.5, 1.0, 0.5)),
+    )
+    camera = scene.add_sensor(
+        gs.sensors.RasterizerCameraOptions(
+            res=res,
+            pos=(3.0, 0.0, 2.0),
+            lookat=(0.0, 0.0, 1.0),
+            up=(0.0, 0.0, 1.0),
+            fov=60.0,
+            near=0.1,
+            far=100.0,
+            lights=[{"pos": (2.0, 2.0, 5.0), "color": (1.0, 1.0, 1.0), "intensity": 5.0}],
+            **cam_kwargs,
+        )
+    )
+    return scene, camera
+
+
+@pytest.mark.required
+@pytest.mark.parametrize("n_envs", [0, 2])
+def test_rasterizer_modalities(n_envs):
+    """Rasterizer camera sensor returns rgb/depth/segmentation/normal with the right shapes, dtypes, and content."""
+    CAM_RES = (128, 96)  # (width, height)
+    W, H = CAM_RES
+    scene, camera = _modality_scene(
+        CAM_RES, render_rgb=True, render_depth=True, render_segmentation=True, render_normal=True
+    )
+    scene.build(n_envs=n_envs)
+    camera._shared_metadata.context.shadow = False
+    for _ in range(3):
+        scene.step()
+
+    data = camera.read()
+    batch = () if n_envs == 0 else (n_envs,)
+    assert data.rgb.shape == (*batch, H, W, 3) and data.rgb.dtype == torch.uint8
+    assert data.depth.shape == (*batch, H, W) and data.depth.dtype == torch.float32
+    assert data.segmentation.shape == (*batch, H, W) and data.segmentation.dtype == torch.int32
+    assert data.normal.shape == (*batch, H, W, 3) and data.normal.dtype == torch.float32
+
+    depth = data.depth
+    finite = depth[torch.isfinite(depth)]
+    assert (finite > 0).all(), "depth must be positive"
+    assert (finite < 99.0).any(), "expected geometry closer than the far plane"
+    assert torch.unique(data.segmentation).numel() > 1, "expected multiple segmentation ids"
+
+
+@pytest.mark.required
+def test_rasterizer_modality_defaults_rgb_only():
+    """Default options request only RGB; the other modalities read back as None."""
+    scene, camera = _modality_scene((64, 64))
+    scene.build(n_envs=0)
+    camera._shared_metadata.context.shadow = False
+    scene.step()
+    data = camera.read()
+    assert data.rgb is not None
+    assert data.depth is None and data.segmentation is None and data.normal is None
+    # Camera sensors are read via sensor.read(), never through read_sensors().
+    assert scene.read_sensors() == {}
+
+
+@pytest.mark.required
+def test_camera_modalities_require_at_least_one():
+    with pytest.raises(gs.GenesisException, match="at least one"):
+        gs.sensors.RasterizerCameraOptions(
+            render_rgb=False, render_depth=False, render_segmentation=False, render_normal=False
+        )
+
+
+@pytest.mark.slow
+@pytest.mark.required
+def test_rasterizer_modalities_match_add_camera():
+    """Rendered depth/segmentation from the sensor match a scene.add_camera render of the same pose."""
+    CAM_RES = (128, 96)
+    scene, sensor = _modality_scene(CAM_RES, render_rgb=False, render_depth=True, render_segmentation=True)
+    ref = scene.add_camera(
+        res=CAM_RES, pos=(3.0, 0.0, 2.0), lookat=(0.0, 0.0, 1.0), up=(0.0, 0.0, 1.0), fov=60.0, near=0.1, far=100.0
+    )
+    scene.build(n_envs=0)
+    sensor._shared_metadata.context.shadow = False
+    scene.step()
+
+    data = sensor.read()
+    _, ref_depth, ref_seg, _ = ref.render(rgb=False, depth=True, segmentation=True, force_render=True)
+
+    sensor_depth = tensor_to_array(data.depth)
+    ref_depth = tensor_to_array(ref_depth)
+    # Silhouette/edge pixels can differ between two independent rasterizations; require the vast majority to agree.
+    close_frac = float((np.abs(sensor_depth - ref_depth) < 0.05).mean())
+    assert close_frac > 0.95, f"sensor vs add_camera depth agreement too low: {close_frac:.3f}"
+
+    # Segmentation is a foreground/background structure: the non-background masks should overlap almost perfectly.
+    sensor_fg = tensor_to_array(data.segmentation) > 0
+    ref_fg = tensor_to_array(ref_seg) > 0
+    iou = float((sensor_fg & ref_fg).sum()) / float((sensor_fg | ref_fg).sum())
+    assert iou > 0.95, f"sensor vs add_camera segmentation IoU too low: {iou:.3f}"
+
+
+@pytest.mark.required
+@pytest.mark.parametrize("backend", [gs.cuda])
+@pytest.mark.parametrize("n_envs", [0, 2])
+@pytest.mark.skipif(not ENABLE_MADRONA, reason=SKIP_NO_MADRONA)
+def test_batch_renderer_modalities(n_envs):
+    """Batch renderer camera sensors support all four modalities, incl. cameras requesting different subsets."""
+    CAM_RES = (128, 96)
+    W, H = CAM_RES
+    scene = gs.Scene(show_viewer=False)
+    scene.add_entity(morph=gs.morphs.Plane())
+    scene.add_entity(
+        morph=gs.morphs.Sphere(radius=0.5, pos=(0.0, 0.0, 1.0)),
+        surface=gs.surfaces.Default(color=(1.0, 0.5, 0.5)),
+    )
+    common = dict(res=CAM_RES, pos=(-2.0, 0.0, 1.5), lookat=(0.0, 0.0, 1.0), up=(0.0, 0.0, 1.0), fov=70.0)
+    cam_all = scene.add_sensor(
+        gs.sensors.BatchRendererCameraOptions(
+            **common, render_rgb=True, render_depth=True, render_segmentation=True, render_normal=True
+        )
+    )
+    # A second camera in the same batch requesting only depth exercises the per-sensor modality union path.
+    cam_depth = scene.add_sensor(
+        gs.sensors.BatchRendererCameraOptions(**common, render_rgb=False, render_depth=True)
+    )
+    scene.build(n_envs=n_envs)
+    scene.step()
+
+    batch = () if n_envs == 0 else (n_envs,)
+    data_all = cam_all.read()
+    assert data_all.rgb.shape == (*batch, H, W, 3) and data_all.rgb.dtype == torch.uint8
+    assert data_all.depth.shape == (*batch, H, W) and data_all.depth.dtype == torch.float32
+    assert data_all.segmentation.shape == (*batch, H, W) and data_all.segmentation.dtype == torch.int32
+    assert data_all.normal.shape == (*batch, H, W, 3) and data_all.normal.dtype == torch.float32
+
+    data_depth = cam_depth.read()
+    assert data_depth.rgb is None and data_depth.segmentation is None and data_depth.normal is None
+    assert data_depth.depth.shape == (*batch, H, W)

--- a/tests/test_sensor_camera.py
+++ b/tests/test_sensor_camera.py
@@ -771,6 +771,24 @@ def test_rasterizer_modality_defaults_rgb_only():
     assert scene.read_sensors() == {}
 
 
+@pytest.mark.required
+def test_read_cameras():
+    # Cameras are excluded from the vector reader and returned by the dedicated camera reader.
+    W, H = 64, 48
+    scene, camera = _modality_scene((W, H), render_depth=True)
+    scene.build(n_envs=0)
+    camera._shared_metadata.context.shadow = False
+    scene.step()
+
+    assert scene.read_sensors() == {}
+
+    cams = scene.read_cameras()
+    assert list(cams.keys()) == [camera]
+    data = cams[camera]
+    assert data.rgb is not None and data.rgb.shape == (H, W, 3)
+    assert data.depth is not None and data.depth.shape == (H, W)
+
+
 @pytest.mark.slow
 @pytest.mark.required
 def test_camera_coexists_with_ring_pipeline_sensor():

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -2403,10 +2403,11 @@ def test_read_sensors_bulk_api(show_viewer, n_envs):
         ),
     )
 
-    # Diverse sensor set covering multiple dtypes (float for IMU/ContactForce, bool for Contact, uint8 for the static
-    # camera) and heterogeneous per-sensor cache sizes within the float dtype (9 cells for IMU vs 3 for ContactForce).
-    # Two IMUs on box_a, one IMU on box_b. ContactForce and Contact sensors on both boxes. A static camera not attached
-    # to any entity (entity_idx defaults to -1).
+    # Diverse sensor set covering multiple dtypes (float for IMU/ContactForce, bool for Contact) and heterogeneous
+    # per-sensor cache sizes within the float dtype (9 cells for IMU vs 3 for ContactForce). Two IMUs on box_a, one IMU
+    # on box_b. ContactForce and Contact sensors on both boxes. A static camera (entity_idx defaults to -1) is added to
+    # confirm that camera sensors are excluded from `read_sensors()` (they own multi-dtype image buffers read via
+    # `sensor.read()`).
     imu_a1 = scene.add_sensor(
         gs.sensors.IMU(
             entity_idx=box_a.idx,
@@ -2452,8 +2453,9 @@ def test_read_sensors_bulk_api(show_viewer, n_envs):
     for _ in range(5):
         scene.step()
 
-    # Scene-wide read returns every sensor class. Per-entity reads restrict to classes present on that entity, so the
-    # static camera class is excluded from both box_a and box_b reads. Each call allocates a fresh tensor per class.
+    # Scene-wide read returns every manager-cached sensor class. Camera sensors are excluded (they store multi-dtype
+    # images in their own cache and are read via `sensor.read()`). Per-entity reads restrict to classes present on that
+    # entity. Each call allocates a fresh tensor per class.
     scene_data = scene.read_sensors()
     a_data = box_a.read_sensors()
     b_data = box_b.read_sensors()
@@ -2461,10 +2463,13 @@ def test_read_sensors_bulk_api(show_viewer, n_envs):
         gs.sensors.types.IMU,
         gs.sensors.types.ContactForce,
         gs.sensors.types.Contact,
-        gs.sensors.types.RasterizerCameraOptions,
     }
+    assert gs.sensors.types.RasterizerCameraOptions not in scene_data
     assert set(a_data.keys()) == {gs.sensors.types.IMU, gs.sensors.types.ContactForce, gs.sensors.types.Contact}
     assert set(b_data.keys()) == {gs.sensors.types.IMU, gs.sensors.types.ContactForce, gs.sensors.types.Contact}
+
+    # The static camera is still fully functional; it is just read through its own `read()` rather than `read_sensors()`.
+    assert static_cam.read().rgb.shape[-3:] == (32, 32, 3)
 
     # Sensors within a class are sorted by entity_idx, so per-entity reads must match contiguous slices of the
     # scene-wide read.


### PR DESCRIPTION
## Description

Makes camera sensors first-class citizens of the sensor system, in three layered commits.

**1. Multi-modality output.** Camera sensors (Rasterizer/Raytracer/BatchRenderer) produce all four rendering modalities — RGB, depth, segmentation, surface normals — matching `scene.add_camera().render()`. Per-modality dtypes (uint8 rgb, float32 depth/normal, int32 segmentation); `CameraReturnType` widened to `(rgb, depth, segmentation, normal)` with `.rgb` first for back-compat.

**2. First-class in the sensor pipeline.** Generalized `_get_cache_dtype`/`_get_intermediate_dtype` to accept a per-field tuple of dtypes so one sensor can span several per-dtype cache buffers. Removed the `uses_manager_cache` opt-out flag, the vestigial dtype/shape return values, the zero-width-slice padding, and the private per-camera `image_cache`. Cameras now render into the shared cache and gain **delay/jitter/history** through the same ring machinery as every other sensor (no perf regression in the common no-delay case; lazy render preserved). `uses_ring_pipeline` reframed to mean only "uses the `_apply_transform` recurrence timeline rings" and decoupled from delay/history eligibility.

**3. Camera sensors own a `vis.Camera`.** Eliminates the duplicated camera layer: three duck-typed wrapper classes plus a `MinimalVisualizerWrapper` shim that re-implemented pose and intrinsics (`f`/`cx`/`cy`/`distance_center_to_plane` were verbatim-copied), across three inconsistent per-backend patterns.
- Decoupled `vis.Camera` from the full `Visualizer` via a small `CameraBackendProvider` seam (the closed set it reaches for: rasterizer/raytracer/batch_renderer, context, scene, has_display, colorize_seg_idxc_arr). The interactive `Visualizer` satisfies it unchanged, so **`scene.add_camera` is byte-identical**; a `StandaloneCameraBackend` backs headless/sensor rendering.
- Each `CameraSensor` now **owns a `vis.Camera`** and delegates pose/intrinsics/render to it, keeping only the sensor layer on top. Sensors gain `set_pose`, `get_pos/quat/transform/lookat/up`, `intrinsics`, `extrinsics`, `projection_matrix`, `f`/`cx`/`cy`, `distance_center_to_plane`, `render_pointcloud`, and a `camera` accessor. `follow_entity`/recording/GUI stay viz-only.

Net: one camera implementation instead of four, the perception primitives a user needs (deproject depth, project points, calibrate, re-pose a free camera), and the pipeline features (delay/jitter/history) — all through the shared machinery.

## Related Issue

N/A — fork working branch. An upstream issue will be linked when this is promoted to `Genesis-Embodied-AI/genesis-world`.

## Motivation and Context

The camera sensor started as a special-cased side channel (opt-out flag, vestigial values, private image cache, duplicated wrappers). This series turns it into a real sensor that reuses the shared pipeline and the shared `vis.Camera`, removing the workarounds and the duplication while unlocking perception primitives.

## How Has This Been / Can This Be Tested?

`uv run pytest -m required tests/test_sensors.py tests/test_sensor_camera.py tests/test_misc.py tests/test_render.py` (CPU backend).

- Regression oracles unchanged: raycaster (multi-field), contact_force (float→bool), IMU, temperature, tactile, joint_torque, `read_sensors` bulk API; and `test_render.py` rasterizer render/point-cloud/heterogeneous (proves `scene.add_camera`/`vis.Camera` unchanged).
- Camera tests: rgb/depth/seg/normal round-trip; RGB-only default + `read_sensors()` exclusion; parity vs `add_camera` (depth/seg); attach to rigid + kinematic links, `offset_T`, batched, batched-attached, env-indexing, lookat-entity (snapshots).
- New: camera `delay` (ZOH exact frame) and `history` via the ring pipeline; read-after-reset re-render; float32 depth camera coexisting with a ring-pipeline IMU; sensor `intrinsics`/`extrinsics`/`projection_matrix` match `scene.add_camera`; runtime `set_pose` re-poses a detached camera.
- **Batch renderer (Madrona) and raytracer (Luisa) validated on CI only** — cannot run on the local RTX 5090.

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the documentation accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
