### PR TITLE
[BUG FIX] Fix MJCF include asset-path rewriting (default mesh crash + non-mesh assets)

### DIFF
--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -98,7 +98,11 @@ def build_model(xml, discard_visual, default_armature=None, merge_fixed_links=Fa
                 include_path = parent_path / elem.attrib["file"]
                 include_root = ET.parse(Path(asset_path) / include_path).getroot()
                 for include_elem in include_root.findall(".//mesh"):
-                    include_elem.attrib["file"] = str(include_path.parent / include_elem.attrib["file"])
+                    # `<default><mesh .../></default>` declarations have no `file` attribute, so leave them untouched
+                    # and only rewrite relative paths for mesh assets that reference a file.
+                    mesh_file = include_elem.attrib.get("file")
+                    if mesh_file is not None:
+                        include_elem.attrib["file"] = str(include_path.parent / mesh_file)
                 for child in include_root:
                     mjcf.append(child)
                 mjcf.remove(elem)

--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -97,12 +97,16 @@ def build_model(xml, discard_visual, default_armature=None, merge_fixed_links=Fa
             for elem in tuple(xml_root.findall("include")):
                 include_path = parent_path / elem.attrib["file"]
                 include_root = ET.parse(Path(asset_path) / include_path).getroot()
-                for include_elem in include_root.findall(".//mesh"):
-                    # `<default><mesh .../></default>` declarations have no `file` attribute, so leave them untouched
-                    # and only rewrite relative paths for mesh assets that reference a file.
-                    mesh_file = include_elem.attrib.get("file")
-                    if mesh_file is not None:
-                        include_elem.attrib["file"] = str(include_path.parent / mesh_file)
+                # Rewrite relative asset paths so they resolve against the included file's directory once its
+                # children are flattened into the parent model. `<default>` blocks (e.g.
+                # `<default><mesh maxhullvert="64"/></default>`) carry no `file` attribute and are left untouched.
+                # `<include>` paths are intentionally excluded here: nested includes are resolved on their own via
+                # `include_path` when popped from the stack.
+                for asset_tag in ("mesh", "texture", "hfield", "skin"):
+                    for include_elem in include_root.findall(f".//{asset_tag}"):
+                        asset_file = include_elem.attrib.get("file")
+                        if asset_file is not None:
+                            include_elem.attrib["file"] = str(include_path.parent / asset_file)
                 for child in include_root:
                     mjcf.append(child)
                 mjcf.remove(elem)

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -13,6 +13,7 @@ import numpy as np
 import pytest
 import torch
 import trimesh
+from PIL import Image
 from scipy.spatial import ConvexHull
 from scipy.spatial.qhull import QhullError
 
@@ -4962,20 +4963,29 @@ def test_mjcf_parsing_with_include():
     assert_allclose(robot1.get_qpos(), robot3.get_qpos(), tol=gs.EPS)
 
 
-def test_mjcf_parsing_with_include_default_mesh(tmp_path):
-    # A `<default><mesh .../></default>` declaration has no `file` attribute; the include preprocessor must skip
-    # such default-only mesh elements instead of unconditionally rewriting their (missing) `file` path.
+def test_mjcf_parsing_with_include_relative_assets(tmp_path):
+    # Regression for two `<include>` preprocessing bugs, both exercised from a single included file:
+    #  - a `<default><mesh .../></default>` declaration has no `file` attribute and must not be treated as an asset;
+    #  - relative asset paths (here a texture) in an included file living in a subdirectory must be rewritten to
+    #    resolve against that file's directory, not the top-level model directory.
+    asset_dir = tmp_path / "assets"
+    asset_dir.mkdir()
+    Image.new("RGB", (4, 4), color=(128, 64, 32)).save(asset_dir / "checker.png")
+
     included = ET.Element("mujoco", model="included")
     default = ET.SubElement(included, "default")
     ET.SubElement(default, "mesh", maxhullvert="64")
+    asset = ET.SubElement(included, "asset")
+    ET.SubElement(asset, "texture", name="tex", type="2d", file="checker.png")
+    ET.SubElement(asset, "material", name="mat", texture="tex")
     worldbody = ET.SubElement(included, "worldbody")
     body = ET.SubElement(worldbody, "body", name="box_body", pos="0 0 1")
     ET.SubElement(body, "freejoint")
-    ET.SubElement(body, "geom", type="box", size="0.1 0.1 0.1")
-    ET.ElementTree(included).write(tmp_path / "included.xml", encoding="utf-8", xml_declaration=True)
+    ET.SubElement(body, "geom", type="box", size="0.1 0.1 0.1", material="mat")
+    ET.ElementTree(included).write(asset_dir / "included.xml", encoding="utf-8", xml_declaration=True)
 
     main = ET.Element("mujoco", model="main")
-    ET.SubElement(main, "include", file="included.xml")
+    ET.SubElement(main, "include", file="assets/included.xml")
     main_path = tmp_path / "main.xml"
     ET.ElementTree(main).write(main_path, encoding="utf-8", xml_declaration=True)
 

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -4962,6 +4962,37 @@ def test_mjcf_parsing_with_include():
     assert_allclose(robot1.get_qpos(), robot3.get_qpos(), tol=gs.EPS)
 
 
+def test_mjcf_parsing_with_include_default_mesh(tmp_path):
+    # A `<default><mesh .../></default>` declaration has no `file` attribute; the include preprocessor must skip
+    # such default-only mesh elements instead of unconditionally rewriting their (missing) `file` path.
+    included = ET.Element("mujoco", model="included")
+    default = ET.SubElement(included, "default")
+    ET.SubElement(default, "mesh", maxhullvert="64")
+    worldbody = ET.SubElement(included, "worldbody")
+    body = ET.SubElement(worldbody, "body", name="box_body", pos="0 0 1")
+    ET.SubElement(body, "freejoint")
+    ET.SubElement(body, "geom", type="box", size="0.1 0.1 0.1")
+    ET.ElementTree(included).write(tmp_path / "included.xml", encoding="utf-8", xml_declaration=True)
+
+    main = ET.Element("mujoco", model="main")
+    ET.SubElement(main, "include", file="included.xml")
+    main_path = tmp_path / "main.xml"
+    ET.ElementTree(main).write(main_path, encoding="utf-8", xml_declaration=True)
+
+    scene = gs.Scene(
+        show_viewer=False,
+    )
+    entity = scene.add_entity(
+        gs.morphs.MJCF(file=str(main_path)),
+    )
+    scene.build()
+
+    z0 = tensor_to_array(entity.get_pos())[..., 2]
+    for _ in range(10):
+        scene.step()
+    assert (tensor_to_array(entity.get_pos())[..., 2] < z0).all()
+
+
 @pytest.mark.slow  # ~200s
 @pytest.mark.required
 def test_urdf_parsing(show_viewer, tol):


### PR DESCRIPTION
## Description
When loading an MJCF scene that uses `<include>`, the preprocessor rewrites relative mesh paths by iterating over every `<mesh>` element found via `include_root.findall(".//mesh")` and unconditionally accessing its `file` attribute. This also matches `<mesh>` elements inside a `<default>` block (e.g. `<default><mesh maxhullvert="64"/></default>`), which are valid MJCF but carry no `file` attribute, so Genesis crashes with `KeyError: 'file'` during preprocessing even though MuJoCo itself parses the file fine.

The fix skips mesh elements that have no `file` attribute, only rewriting the path for mesh assets that actually reference a file.

## Related Issue
Resolves Genesis-Embodied-AI/Genesis#3016

## Motivation and Context
Default mesh declarations are legal MJCF and commonly appear in included files. Genesis should not reject valid models that MuJoCo accepts.

## How Has This Been / Can This Be Tested?
Added `test_mjcf_parsing_with_include_default_mesh` in `tests/test_rigid_physics.py`, which writes a main MJCF that `<include>`s a child file containing a `<default><mesh maxhullvert="64"/></default>` declaration, loads it, builds the scene, and asserts the free body falls under gravity. The test fails on `main` with `KeyError: 'file'` and passes with this fix.

```
pytest tests/test_rigid_physics.py::test_mjcf_parsing_with_include_default_mesh
```

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
