### PR TITLE
[BUG FIX] Fix wide-batch contact-island slowdown in the monolith constraint solve

### DIFF
--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -4831,10 +4831,9 @@ def func_update_gradient(
         or static_rigid_sim_config.backend == gs.cpu
         or static_rigid_sim_config.enable_per_island_solve
     ):
-        # CPU, or per-island decomposition: the tiled factor/solve operates on the whole-env dense Hessian, but with a
-        # per-island factor nt_H holds the per-island block-diagonal factor, so the gradient solve must go per-island
-        # (func_cholesky_solve_batch). Gated on enable_per_island_solve, not use_contact_island: a single shared-fitting
-        # island uses the whole-env tiled solve, matching islands off.
+        # CPU, or per-island decomposition: the tiled solve operates on the whole-env dense Hessian, but a per-island
+        # factor leaves nt_H block-diagonal by island, so the gradient solve must go per-island via
+        # func_cholesky_solve_batch. A single whole-env island keeps the tiled solve, like islands off.
         qd.loop_config(
             name="update_gradient", serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL, block_dim=32
         )
@@ -5474,13 +5473,10 @@ def _kernel_solve_monolith(
                 and static_rigid_sim_config.solver_type == gs.constraint_solver.Newton
                 and not static_rigid_sim_config.enable_cooperative_constraint_kernels
             ):
-                # Genuine per-island decomposition with the cooperative kernels off: func_solve_init skips the
-                # per-island tiled seed, so the monolith seeds each island's initial scalar factor + gradient + search
-                # here. Gives the first linesearch a valid Newton direction; once per step, then iterate. Gated on
-                # enable_per_island_solve, not use_contact_island: when islands are on but the whole env is a single
-                # shared-fitting block (enable_per_island_solve False), func_solve_init's fast whole-env seed runs
-                # instead - identical to islands off. With cooperative kernels enabled, func_solve_init already seeded
-                # the factor (L persisted to nt_H) and the search direction.
+                # Per-island decomposition with the cooperative kernels off: func_solve_init skips its seed, so the
+                # monolith self-seeds each island's scalar factor + gradient + search here (once per step). Gated on
+                # enable_per_island_solve, so a single whole-env island takes func_solve_init's fast seed instead, like
+                # islands off. With the cooperative kernels on, func_solve_init already seeded the factor (L in nt_H).
                 func_hessian_and_cholesky_factor_direct_batch(
                     i_b,
                     island_state=island_state,

--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -4829,10 +4829,12 @@ def func_update_gradient(
     if qd.static(
         not (static_rigid_sim_config.enable_tiled_cholesky_hessian and static_rigid_sim_config.hessian_fits_shared)
         or static_rigid_sim_config.backend == gs.cpu
-        or static_rigid_sim_config.use_contact_island
+        or static_rigid_sim_config.enable_per_island_solve
     ):
-        # CPU, or islands: the tiled factor/solve operates on the whole-env dense Hessian, but with islands nt_H
-        # holds the per-island block-diagonal factor, so the gradient solve must go per-island (func_cholesky_solve_batch).
+        # CPU, or per-island decomposition: the tiled factor/solve operates on the whole-env dense Hessian, but with a
+        # per-island factor nt_H holds the per-island block-diagonal factor, so the gradient solve must go per-island
+        # (func_cholesky_solve_batch). Gated on enable_per_island_solve, not use_contact_island: a single shared-fitting
+        # island uses the whole-env tiled solve, matching islands off.
         qd.loop_config(
             name="update_gradient", serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL, block_dim=32
         )
@@ -5222,7 +5224,7 @@ def func_solve_init(
             and (
                 is_decomposed
                 or not (
-                    static_rigid_sim_config.use_contact_island
+                    static_rigid_sim_config.enable_per_island_solve
                     and static_rigid_sim_config.backend != gs.cpu
                     and not static_rigid_sim_config.enable_cooperative_constraint_kernels
                 )
@@ -5232,10 +5234,11 @@ def func_solve_init(
             # its first linesearch consumes the search direction computed here (this kernel is its "iteration 0"; the
             # graph then computes each subsequent direction at the end of an iteration). So it ALWAYS needs this seed,
             # islands on or off. The monolith seeds it here except in the one case where its body self-inits the factor
-            # per-env: the GPU island arm with the cooperative kernels disabled (the only case keyed below). With the
-            # cooperative kernels enabled the body does NOT self-init, so the seed must run here even for GPU islands -
-            # otherwise a shared-fitting Hessian at an env count that oversaturates the GPU (where neither the fused nor
-            # the per-island seed branch above fires) would leave Mgrad stale.
+            # per-env: the GPU per-island-decomposition arm (enable_per_island_solve) with the cooperative kernels
+            # disabled (the only case keyed below). With the cooperative kernels enabled the body does NOT self-init, so
+            # the seed must run here even for per-island decomposition - otherwise a shared-fitting Hessian at an env
+            # count that oversaturates the GPU (where neither the fused nor the per-island seed branch above fires)
+            # would leave Mgrad stale.
             # compute_envelope=True computes each island's structural skyline envelope once, reused per iteration.
             func_hessian_and_cholesky_factor_direct(
                 island_state=island_state,
@@ -5250,15 +5253,16 @@ def func_solve_init(
             not (
                 static_rigid_sim_config.solver_type == gs.constraint_solver.Newton
                 and not is_decomposed
-                and static_rigid_sim_config.use_contact_island
+                and static_rigid_sim_config.enable_per_island_solve
                 and static_rigid_sim_config.backend != gs.cpu
                 and not static_rigid_sim_config.enable_cooperative_constraint_kernels
             )
         ):
             # Initial gradient (Mgrad = H^-1 grad for Newton, grad for CG). Seeds the decomposed arm's first search
-            # direction, so it runs for the decomposed arm in all cases. Skipped only for the GPU island monolith with
-            # the cooperative kernels disabled, which self-inits the gradient per-env in its own body; with them enabled
-            # the body does not self-init, so the seed must run here.
+            # direction, so it runs for the decomposed arm in all cases. Skipped only for the GPU per-island-
+            # decomposition monolith (enable_per_island_solve) with the cooperative kernels disabled, which self-inits
+            # the gradient per-env in its own body; with them enabled the body does not self-init, so the seed must run
+            # here.
             func_update_gradient(
                 dofs_state=dofs_state,
                 entities_info=entities_info,
@@ -5465,15 +5469,18 @@ def _kernel_solve_monolith(
             has_awake_work = has_awake_work and rigid_global_info.n_awake_dofs[i_b] > 0
         if has_awake_work:
             if qd.static(
-                static_rigid_sim_config.use_contact_island
+                static_rigid_sim_config.enable_per_island_solve
                 and static_rigid_sim_config.backend != gs.cpu
                 and static_rigid_sim_config.solver_type == gs.constraint_solver.Newton
                 and not static_rigid_sim_config.enable_cooperative_constraint_kernels
             ):
-                # Without the cooperative kernels, func_solve_init skips the GPU-island tiled seed, so the monolith
-                # seeds this env's initial scalar per-island factor + gradient + search here. Gives the first
-                # linesearch a valid Newton direction; once per step, then iterate. With cooperative kernels enabled,
-                # func_solve_init already seeded the factor (L persisted to nt_H) and the search direction.
+                # Genuine per-island decomposition with the cooperative kernels off: func_solve_init skips the
+                # per-island tiled seed, so the monolith seeds each island's initial scalar factor + gradient + search
+                # here. Gives the first linesearch a valid Newton direction; once per step, then iterate. Gated on
+                # enable_per_island_solve, not use_contact_island: when islands are on but the whole env is a single
+                # shared-fitting block (enable_per_island_solve False), func_solve_init's fast whole-env seed runs
+                # instead - identical to islands off. With cooperative kernels enabled, func_solve_init already seeded
+                # the factor (L persisted to nt_H) and the search direction.
                 func_hessian_and_cholesky_factor_direct_batch(
                     i_b,
                     island_state=island_state,

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -487,14 +487,18 @@ class RigidSolver(KinematicSolver):
         # The subgroup-cooperative constraint kernels (and the batch-first layout they expect) win when per-env compute
         # density amortizes the warp-per-env overhead, and lose when envs are sparse and many (the 1-thread-per-env path
         # is already coalesced under (len_constraints_, _B)). They are also the layout the decomposed solve arm requires.
-        # Empirically the cooperative path wins around 4096 envs at n_dofs >= ~18 and washes out by ~30000 envs at
-        # n_dofs <= ~12; the n_envs <= 8192 and n_dofs >= 16 thresholds bound that crossover. Sparse solve is excluded
-        # (the cooperative qfrc kernel and the flipped-layout jac readers are dense-only).
+        # Empirically the cooperative path wins from ~4096 envs at n_dofs >= ~18 and loses once the env dimension alone
+        # saturates the GPU: measured on an RTX PRO 6000 (get_gpu_core_count() == 16384), n_dofs 18 still wins at 16384
+        # envs (+13-19%) and loses by 24576; n_dofs 60 is neutral in that range and loses badly past saturation. So the
+        # env bound is get_gpu_core_count() - the same GPU-saturation threshold envs_undersaturate uses below - not a
+        # fixed literal (a hardcoded 8192 dropped the cooperative kernels while envs still undersaturated, an ~8x cliff
+        # for islands). Combined with n_dofs >= 16. Sparse solve is excluded (the cooperative qfrc kernel and the
+        # flipped-layout jac readers are dense-only).
         enable_cooperative_constraint_kernels = (
             gs.backend != gs.cpu
             and not self.sim.options.requires_grad
             and not sparse_solve
-            and self._sim._B <= 8192
+            and self._sim._B <= get_gpu_core_count()
             and self.n_dofs >= 16
         )
         constraint_layout_batch_first = (

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -488,11 +488,8 @@ class RigidSolver(KinematicSolver):
         # density amortizes the warp-per-env overhead, and lose when envs are sparse and many (the 1-thread-per-env path
         # is already coalesced under (len_constraints_, _B)). They are also the layout the decomposed solve arm requires.
         # Empirically the cooperative path wins from ~4096 envs at n_dofs >= ~18 and loses once the env dimension alone
-        # saturates the GPU: measured on an RTX PRO 6000 (get_gpu_core_count() == 16384), n_dofs 18 still wins at 16384
-        # envs (+13-19%) and loses by 24576; n_dofs 60 is neutral in that range and loses badly past saturation. So the
-        # env bound is get_gpu_core_count() - the same GPU-saturation threshold envs_undersaturate uses below - not a
-        # fixed literal (a hardcoded 8192 dropped the cooperative kernels while envs still undersaturated, an ~8x cliff
-        # for islands). Combined with n_dofs >= 16. Sparse solve is excluded (the cooperative qfrc kernel and the
+        # saturates the GPU, so the env bound is get_gpu_core_count() (the threshold envs_undersaturate uses below), not
+        # a fixed literal, combined with n_dofs >= 16. Sparse solve is excluded (the cooperative qfrc kernel and the
         # flipped-layout jac readers are dense-only).
         enable_cooperative_constraint_kernels = (
             gs.backend != gs.cpu

--- a/tests/test_rigid_physics_island.py
+++ b/tests/test_rigid_physics_island.py
@@ -376,13 +376,10 @@ def test_island_monolith_seed_oversaturated(show_viewer, monkeypatch):
 @pytest.mark.parametrize("backend", [gs.gpu])
 @pytest.mark.parametrize("n_envs", [0, 2])
 def test_island_whole_env_matches_off(show_viewer, n_envs):
-    # Below 16 dofs the cooperative kernels are disabled (coop is gated on n_dofs >= 16), and a scene whose Hessian fits
-    # the shared tile resolves enable_per_island_solve False. That is exactly the config the monolith seed path gates:
-    # it must track enable_per_island_solve, not use_contact_island, so turning islands on does not change the result
-    # (with a single shared-fitting island the whole-env seed IS the per-island result). Two free boxes = 12 dofs reach
-    # this without faking GPU saturation. A seed gated on use_contact_island alone would run the redundant in-kernel
-    # per-env scalar factor (the >8192-env slowdown); done wrong (branch removed without the func_solve_init seed) it
-    # would leave Mgrad stale and the boxes would fall through the floor.
+    # Below 16 dofs the cooperative kernels are off (gated on n_dofs >= 16) and a shared-fitting Hessian resolves
+    # enable_per_island_solve False - the config where the monolith seed must track enable_per_island_solve, not
+    # use_contact_island, so turning islands on does not change the result (a single whole-env island's seed is the
+    # per-island result). Two free boxes = 12 dofs reach it without faking GPU saturation.
     positions = []
     for use_contact_island in (False, True):
         scene = gs.Scene(
@@ -405,8 +402,8 @@ def test_island_whole_env_matches_off(show_viewer, n_envs):
 
         if use_contact_island:
             cfg = scene.rigid_solver._static_rigid_sim_config
-            # Guard that the scene sits in the gated branch (islands on, coop off, no per-island decomposition), so the
-            # test keeps exercising the use_contact_island-vs-enable_per_island_solve seed gate it protects.
+            # Guard the scene stays in the gated config (islands on, coop off, no per-island decomposition) so the test
+            # keeps exercising the seed gate.
             assert not cfg.enable_cooperative_constraint_kernels
             assert not cfg.enable_per_island_solve
 
@@ -416,13 +413,12 @@ def test_island_whole_env_matches_off(show_viewer, n_envs):
         z = np.stack([np.atleast_1d(tensor_to_array(box.get_pos())[..., 2]) for box in boxes])
         vel = tensor_to_array(scene.rigid_solver.get_dofs_velocity())
         assert not np.isnan(z).any()
-        # Rest on the floor at half the box size; a stale seed (broken fix) never applies the contact response.
+        # Rest on the floor at half the box size; a stale seed would never apply the contact response.
         assert_allclose(z, 0.05, tol=5e-3)
         assert np.abs(vel).max() < 0.1
         positions.append(np.stack([tensor_to_array(box.get_pos()) for box in boxes]))
 
-    # The invariant the fix protects: with a single shared-fitting island per body, use_contact_island must not change
-    # the result - islands on is identical to islands off.
+    # With a single shared-fitting island per body, use_contact_island must not change the result.
     assert_allclose(positions[1], positions[0], tol=5e-3)
 
 

--- a/tests/test_rigid_physics_island.py
+++ b/tests/test_rigid_physics_island.py
@@ -315,12 +315,11 @@ def test_solve_correctness(show_viewer, noslip_iterations, n_envs):
 @pytest.mark.required
 @pytest.mark.parametrize("backend", [gs.gpu])
 def test_island_monolith_seed_oversaturated(show_viewer, monkeypatch):
-    # The GPU island monolith leaves its initial factor + gradient to func_solve_init, except when its body self-inits
-    # them per-env - which it only does when the cooperative kernels are disabled. With them enabled, func_solve_init
-    # must seed: for a shared-fitting Hessian at an env count that oversaturates the GPU, neither the fused nor the
-    # per-island seed branch fires, so the fallback factor+gradient must run, else Mgrad stays stale and the solve
-    # makes no progress (the boxes fall through the floor). Faking GPU saturation (get_gpu_core_count -> 1) reaches the
-    # oversaturated path at 2 envs instead of the thousands a real GPU would need.
+    # enable_cooperative_constraint_kernels is bounded by get_gpu_core_count(), so faking extreme GPU saturation
+    # (get_gpu_core_count -> 1) disables the cooperative kernels at 2 envs - a small-scale stand-in for the
+    # >get_gpu_core_count() env regime. With islands on and the monolith arm pinned the whole env is a single
+    # shared-fitting block (enable_per_island_solve False), so the in-kernel branch A is gated off and func_solve_init
+    # must supply the seed factor + gradient; otherwise Mgrad stays stale and the boxes fall through the floor.
     import genesis.engine.solvers.rigid.rigid_solver as rigid_solver
     from genesis.utils.array_class import RigidSimStaticConfig
 
@@ -342,8 +341,8 @@ def test_island_monolith_seed_oversaturated(show_viewer, monkeypatch):
         show_viewer=show_viewer,
     )
     scene.add_entity(gs.morphs.Plane())
-    # Four spaced free boxes: 24 dofs (>= 16, so the cooperative kernels engage) that fit the shared tile, and four
-    # independent islands - exactly the shared-fitting multi-island case the seed branches gate out.
+    # Four spaced free boxes: 24 dofs (cooperative-eligible at n_dofs >= 16, but disabled here by the faked saturation)
+    # that fit the shared tile, four independent islands - the shared-fitting case where the in-kernel seed gates off.
     boxes = [
         scene.add_entity(
             gs.morphs.Box(
@@ -357,7 +356,7 @@ def test_island_monolith_seed_oversaturated(show_viewer, monkeypatch):
 
     cfg = scene.rigid_solver._static_rigid_sim_config
     # Guard against the test silently ceasing to exercise the gap (e.g. if the saturation heuristic changes).
-    assert cfg.enable_cooperative_constraint_kernels
+    assert not cfg.enable_cooperative_constraint_kernels
     assert not cfg.enable_fused_factor_solve_init
     assert not cfg.enable_per_island_solve
 
@@ -370,56 +369,6 @@ def test_island_monolith_seed_oversaturated(show_viewer, monkeypatch):
     # The boxes rest on the floor at half their size; a stale seed would never apply the contact response.
     assert_allclose(z, 0.05, tol=5e-3)
     assert np.abs(vel).max() < 0.1
-
-
-@pytest.mark.required
-@pytest.mark.parametrize("backend", [gs.gpu])
-@pytest.mark.parametrize("n_envs", [0, 2])
-def test_island_whole_env_matches_off(show_viewer, n_envs):
-    # Below 16 dofs the cooperative kernels are off (gated on n_dofs >= 16) and a shared-fitting Hessian resolves
-    # enable_per_island_solve False - the config where the monolith seed must track enable_per_island_solve, not
-    # use_contact_island, so turning islands on does not change the result (a single whole-env island's seed is the
-    # per-island result). Two free boxes = 12 dofs reach it without faking GPU saturation.
-    positions = []
-    for use_contact_island in (False, True):
-        scene = gs.Scene(
-            rigid_options=gs.options.RigidOptions(
-                use_contact_island=use_contact_island,
-            ),
-            show_viewer=show_viewer,
-        )
-        scene.add_entity(gs.morphs.Plane())
-        boxes = [
-            scene.add_entity(
-                gs.morphs.Box(
-                    size=(0.1, 0.1, 0.1),
-                    pos=(0.4 * i, 0.0, 0.2),
-                )
-            )
-            for i in range(2)
-        ]
-        scene.build(n_envs=n_envs)
-
-        if use_contact_island:
-            cfg = scene.rigid_solver._static_rigid_sim_config
-            # Guard the scene stays in the gated config (islands on, coop off, no per-island decomposition) so the test
-            # keeps exercising the seed gate.
-            assert not cfg.enable_cooperative_constraint_kernels
-            assert not cfg.enable_per_island_solve
-
-        for _ in range(150):
-            scene.step()
-
-        z = np.stack([np.atleast_1d(tensor_to_array(box.get_pos())[..., 2]) for box in boxes])
-        vel = tensor_to_array(scene.rigid_solver.get_dofs_velocity())
-        assert not np.isnan(z).any()
-        # Rest on the floor at half the box size; a stale seed would never apply the contact response.
-        assert_allclose(z, 0.05, tol=5e-3)
-        assert np.abs(vel).max() < 0.1
-        positions.append(np.stack([tensor_to_array(box.get_pos()) for box in boxes]))
-
-    # With a single shared-fitting island per body, use_contact_island must not change the result.
-    assert_allclose(positions[1], positions[0], tol=5e-3)
 
 
 @pytest.mark.required

--- a/tests/test_rigid_physics_island.py
+++ b/tests/test_rigid_physics_island.py
@@ -373,6 +373,60 @@ def test_island_monolith_seed_oversaturated(show_viewer, monkeypatch):
 
 
 @pytest.mark.required
+@pytest.mark.parametrize("backend", [gs.gpu])
+@pytest.mark.parametrize("n_envs", [0, 2])
+def test_island_whole_env_matches_off(show_viewer, n_envs):
+    # Below 16 dofs the cooperative kernels are disabled (coop is gated on n_dofs >= 16), and a scene whose Hessian fits
+    # the shared tile resolves enable_per_island_solve False. That is exactly the config the monolith seed path gates:
+    # it must track enable_per_island_solve, not use_contact_island, so turning islands on does not change the result
+    # (with a single shared-fitting island the whole-env seed IS the per-island result). Two free boxes = 12 dofs reach
+    # this without faking GPU saturation. A seed gated on use_contact_island alone would run the redundant in-kernel
+    # per-env scalar factor (the >8192-env slowdown); done wrong (branch removed without the func_solve_init seed) it
+    # would leave Mgrad stale and the boxes would fall through the floor.
+    positions = []
+    for use_contact_island in (False, True):
+        scene = gs.Scene(
+            rigid_options=gs.options.RigidOptions(
+                use_contact_island=use_contact_island,
+            ),
+            show_viewer=show_viewer,
+        )
+        scene.add_entity(gs.morphs.Plane())
+        boxes = [
+            scene.add_entity(
+                gs.morphs.Box(
+                    size=(0.1, 0.1, 0.1),
+                    pos=(0.4 * i, 0.0, 0.2),
+                )
+            )
+            for i in range(2)
+        ]
+        scene.build(n_envs=n_envs)
+
+        if use_contact_island:
+            cfg = scene.rigid_solver._static_rigid_sim_config
+            # Guard that the scene sits in the gated branch (islands on, coop off, no per-island decomposition), so the
+            # test keeps exercising the use_contact_island-vs-enable_per_island_solve seed gate it protects.
+            assert not cfg.enable_cooperative_constraint_kernels
+            assert not cfg.enable_per_island_solve
+
+        for _ in range(150):
+            scene.step()
+
+        z = np.stack([np.atleast_1d(tensor_to_array(box.get_pos())[..., 2]) for box in boxes])
+        vel = tensor_to_array(scene.rigid_solver.get_dofs_velocity())
+        assert not np.isnan(z).any()
+        # Rest on the floor at half the box size; a stale seed (broken fix) never applies the contact response.
+        assert_allclose(z, 0.05, tol=5e-3)
+        assert np.abs(vel).max() < 0.1
+        positions.append(np.stack([tensor_to_array(box.get_pos()) for box in boxes]))
+
+    # The invariant the fix protects: with a single shared-fitting island per body, use_contact_island must not change
+    # the result - islands on is identical to islands off.
+    assert_allclose(positions[1], positions[0], tol=5e-3)
+
+
+@pytest.mark.required
 @pytest.mark.parametrize("n_envs", [0, 2])
 def test_pruning(show_viewer, n_envs):
     # A convex-decomposed box is a compound body (27 sub-box geoms on one link), so its ground contacts pile up per


### PR DESCRIPTION
## Description

Two related fixes to the GPU rigid constraint solver that remove an ~8x slowdown at large batch sizes when contact islands are enabled (the default since #2974).

**1. Gate the monolith solve's seed path on `enable_per_island_solve`, not `use_contact_island`.**
`_kernel_solve_monolith` had a `qd.static` branch (and two matching `func_solve_init` skip-conditions plus the `func_update_gradient` batch-vs-tiled selection) keyed on `use_contact_island`. Every *downstream* factor/solve/iteration already keys on `enable_per_island_solve`. When islands are on but the whole env is a single shared-fitting block (`enable_per_island_solve` resolves `False` - GPU, no hibernation, Hessian fits shared), the seed was forced through a redundant per-env **scalar** dense Cholesky instead of the tiled cooperative seed the islands-off path uses. Switching those four sites to `enable_per_island_solve` makes a single-island env solve byte-identically to islands off. The fused fast-seed branch stays on `use_contact_island` (it already means "islands on and not decomposed").

**2. Bound `enable_cooperative_constraint_kernels` by `get_gpu_core_count()` instead of a hardcoded `8192`.**
The cliff edge was the literal `self._sim._B <= 8192`, which dropped the cooperative kernels while the env dimension still undersaturated the GPU (`get_gpu_core_count()` is 16384 on an RTX PRO 6000, and `envs_undersaturate` in the same function already uses it). A sweep confirms cooperative kernels keep winning up to GPU saturation, so this aligns the two thresholds.

## Related Issue

No tracked issue. This is a performance regression introduced by #2974 ("enable islands by default"), found by git-bisection (first-bad commit `9c7f9e6c`).

## Motivation and Context

On the no-sensor box-pyramid benchmark at 16384 envs (RTX PRO 6000), `use_contact_island=True` (the default) ran ~8x slower than `False`. Bisection localized the regression to #2974/`9c7f9e6c`; kernel profiling showed the *entire* delta is one kernel, `_kernel_solve_monolith` (163 ms/step islands-on vs 15 ms islands-off), all other kernels unchanged. Root cause: the seed factorization was mis-gated (see Description). The fix restores parity:

| n_envs | islands off | islands on (before) | islands on (after) |
|---|---|---|---|
| 16384 | ~610k FPS | ~76k FPS | ~636k FPS |

Cooperative-cutoff sweep (islands off, coop on vs off, FPS median):

| n_dofs | n_envs | coop ON | coop OFF |
|---|---|---|---|
| 18 | 12288 | 6.42M | 5.37M (+19%) |
| 18 | 16384 | 6.60M | 5.84M (+13%) |
| 18 | 24576 | 6.01M | 6.34M (coop loses past saturation) |
| 60 | 16384 | 0.642M | 0.617M |
| 60 | 24576 | 0.312M | 0.517M (coop loses past saturation) |

## How Has This Been / Can This Be Tested?

- `tests/test_rigid_physics_island.py::test_island_monolith_seed_oversaturated` (GPU) is updated for this change: it fakes extreme GPU saturation (`get_gpu_core_count -> 1`), which - now that the cooperative cutoff is bounded by `get_gpu_core_count()` - disables the cooperative kernels at 2 envs, reaching the coop-off monolith seed (islands on, `enable_per_island_solve` False, 24 dofs). It guards the resolved static config and asserts the boxes rest on the floor; a broken seed gate (branch A removed without the compensating `func_solve_init` seed) leaves Mgrad stale and the boxes tunnel. This is a more representative stand-in for the >`get_gpu_core_count()` env regression than a `<16`-dof scene.
- `test_solve_correctness` (islands on == off on the cooperative path) is unchanged and passes; the full `tests/test_rigid_physics_island.py` suite (29 tests) passes with the fix on an RTX 5090.
- Verified end-to-end on an RTX PRO 6000 at 12288/16384 envs: islands-on recovers to ~610-636k FPS and now runs with cooperative kernels engaged.

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the documentation accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.