### PR TITLE
[FEATURE] Add MuJoCo tendon support (fixed and spatial)

### DIFF
--- a/examples/rigid/tendon_arm.py
+++ b/examples/rigid/tendon_arm.py
@@ -1,0 +1,47 @@
+import argparse
+
+import numpy as np
+
+import genesis as gs
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-v", "--vis", action="store_true", default=False)
+    args = parser.parse_args()
+
+    ########################## init ##########################
+    gs.init(precision="32", logging_level="info")
+
+    ########################## create a scene ##########################
+    scene = gs.Scene(
+        viewer_options=gs.options.ViewerOptions(
+            camera_pos=(1.5, -1.5, 1.5),
+            camera_lookat=(0.2, 0.0, 1.0),
+            camera_fov=40,
+        ),
+        show_viewer=args.vis,
+    )
+
+    ########################## a self-authored tendon-driven arm ##########################
+    # A spatial tendon ("flexor") is routed from a fixed anchor, wraps around a cylinder pulley, and attaches to the
+    # forearm tip. A position actuator drives the tendon length to flex the arm. A fixed tendon ("couple") links the
+    # two joints. See genesis/assets/xml/tendon_arm.xml.
+    arm = scene.add_entity(gs.morphs.MJCF(file="xml/tendon_arm.xml"))
+
+    scene.build()
+
+    print(f"tendons: {[t.name for t in arm.tendons]}")
+    flexor = arm.get_tendon("flexor")
+
+    ########################## pull on the flexor tendon to flex the arm ##########################
+    for i in range(1000):
+        # Oscillate the target tendon length between slack and taut.
+        phase = 0.5 * (1.0 - np.cos(2.0 * np.pi * i / 300.0))
+        target = 0.6 + 0.5 * phase
+        arm.solver.control_tendons_position(np.array([target]), tendons_idx=[flexor.idx])
+        scene.step()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/rigid/tendon_interaction.py
+++ b/examples/rigid/tendon_interaction.py
@@ -1,0 +1,109 @@
+"""
+Interactive Tendon Arm
+======================
+
+A 2-link arm driven by a MuJoCo-style SPATIAL tendon that routes from a fixed anchor, wraps around a cylinder
+"pulley", and attaches to the forearm tip; a FIXED tendon couples the two joints, and a position actuator drives the
+spatial tendon's length. Grab the arm with the mouse to feel the tendon resist, and tighten/loosen the flexor tendon
+live. See genesis/assets/xml/tendon_arm.xml.
+
+Usage:
+    python tendon_interaction.py
+
+Controls:
+    up / down   - tighten / loosen the flexor tendon
+    left-drag   - grab and drag the arm (MouseInteraction plugin)
+    ESC         - quit
+"""
+
+import argparse
+import os
+
+import numpy as np
+
+import genesis as gs
+from genesis.vis.keybindings import Key, KeyAction, Keybind
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--position", "-p", action="store_true", help="Drag by setting position instead of applying spring forces"
+    )
+    args = parser.parse_args()
+
+    gs.init(backend=gs.cpu)
+
+    scene = gs.Scene(
+        viewer_options=gs.options.ViewerOptions(
+            camera_pos=(1.6, -1.6, 1.6),
+            camera_lookat=(0.2, 0.0, 1.0),
+            camera_fov=40,
+        ),
+        show_viewer=True,
+    )
+
+    arm = scene.add_entity(
+        gs.morphs.MJCF(file="xml/tendon_arm.xml"),
+    )
+
+    # Drag the arm with the mouse; spring-force mode (default) lets the tendon visibly resist your pull.
+    scene.viewer.add_plugin(
+        gs.vis.viewer_plugins.MouseInteractionPlugin(
+            use_force=not args.position,
+            color=(0.9, 0.4, 0.2, 0.6),
+        ),
+    )
+
+    scene.build()
+
+    # Start in a pose where the flexor tendon drapes over the pulley, so the wrap is visible from the first frame.
+    arm.set_qpos(np.array([0.75, -0.5]))
+
+    flexor_idx = arm.get_tendon("flexor").idx
+
+    # The viewer runs in its own thread, so keybind callbacks fire there. They only nudge this plain float; the GPU
+    # tendon-control call runs on the stepping thread below, keeping every kernel launch on one thread.
+    target_length = float(arm.solver.get_tendons_length(tendons_idx=[flexor_idx])[0])
+    is_running = True
+
+    def stop():
+        nonlocal is_running
+        is_running = False
+
+    def tighten():
+        nonlocal target_length
+        target_length = max(0.2, target_length - 0.05)
+
+    def loosen():
+        nonlocal target_length
+        target_length += 0.05
+
+    scene.viewer.register_keybinds(
+        Keybind("quit", Key.ESCAPE, KeyAction.RELEASE, callback=stop),
+        Keybind("tighten_flexor", Key.UP, KeyAction.PRESS, callback=tighten),
+        Keybind("loosen_flexor", Key.DOWN, KeyAction.PRESS, callback=loosen),
+        overwrite=True,
+    )
+
+    print("\nTendon-arm controls:")
+    print("up / down - tighten / loosen the flexor tendon")
+    print("left-drag - grab and drag the arm")
+    print("ESC       - quit\n")
+
+    tendon_nodes = []
+    while is_running and scene.viewer.is_alive():
+        arm.solver.control_tendons_position(np.array([target_length]), tendons_idx=[flexor_idx])
+        scene.step()
+
+        # Visualize the spatial tendon's routed/wrapped path (clear only our own lines so the drag overlay stays).
+        for node in tendon_nodes:
+            scene.clear_debug_object(node)
+        tendon_nodes = arm.draw_debug_tendons(color=(0.9, 0.2, 0.2, 1.0), radius=0.006)
+
+        if "PYTEST_VERSION" in os.environ:
+            break
+
+
+if __name__ == "__main__":
+    main()

--- a/genesis/__init__.py
+++ b/genesis/__init__.py
@@ -489,6 +489,8 @@ from .constants import (
     JOINT_TYPE,
     GEOM_TYPE,
     EQUALITY_TYPE,
+    TENDON_TYPE,
+    WRAP_TYPE,
     CTRL_MODE,
     PARA_LEVEL,
     ACTIVE,

--- a/genesis/assets/xml/tendon_arm.xml
+++ b/genesis/assets/xml/tendon_arm.xml
@@ -1,0 +1,50 @@
+<mujoco model="tendon_arm">
+  <!--
+    Self-authored tendon showcase for Genesis. A 2-link arm actuated by a single SPATIAL tendon that is routed from a
+    fixed anchor site, wraps around a fixed cylinder "pulley", and attaches to the forearm tip. A position actuator
+    drives the tendon length, flexing the arm. A second FIXED tendon couples the two joints so they move together
+    (like a mechanically linked finger). Exercises: spatial tendon + geom wrapping + actuator transmission + a fixed
+    tendon coupling, all in one simple model.
+  -->
+  <compiler angle="radian"/>
+  <option timestep="0.005" gravity="0 0 -9.81"/>
+
+  <worldbody>
+    <site name="anchor" pos="-0.15 0 1.2" size="0.02" rgba="1 0 0 1"/>
+    <geom name="pulley" type="cylinder" pos="0 0 1.0" size="0.06 0.05" euler="1.5708 0 0" rgba="0.6 0.6 0.2 1"
+          contype="0" conaffinity="0"/>
+    <!-- Sidesite pins the wrap to the top (+z) side of the pulley (MuJoCo's stateless side selection), so the tendon
+         does not flip to the shortest-path side as the arm swings. -->
+    <site name="pulley_top" pos="0 0 1.15" size="0.015" rgba="1 1 0 1"/>
+
+    <body name="upper" pos="0 0 1.0">
+      <joint name="shoulder" type="hinge" axis="0 1 0" range="-2.0 2.0"/>
+      <geom type="capsule" fromto="0 0 0 0.3 0 0" size="0.03" mass="0.4" rgba="0.2 0.4 0.8 1"/>
+      <site name="mid" pos="0.3 0 0.04" size="0.02" rgba="0 1 0 1"/>
+      <body name="fore" pos="0.3 0 0">
+        <joint name="elbow" type="hinge" axis="0 1 0" range="-2.0 2.0"/>
+        <geom type="capsule" fromto="0 0 0 0.3 0 0" size="0.03" mass="0.3" rgba="0.2 0.7 0.5 1"/>
+        <site name="tip" pos="0.3 0 0.04" size="0.02" rgba="0 0 1 1"/>
+      </body>
+    </body>
+  </worldbody>
+
+  <tendon>
+    <!-- Spatial actuation tendon: anchor -> wrap over the cylinder pulley (pinned to the top via sidesite) -> tip. -->
+    <spatial name="flexor" width="0.005" rgba="0.9 0.2 0.2 1">
+      <site site="anchor"/>
+      <geom geom="pulley" sidesite="pulley_top"/>
+      <site site="mid"/>
+      <site site="tip"/>
+    </spatial>
+    <!-- Fixed coupling tendon so the two joints share load (illustrative). -->
+    <fixed name="couple" stiffness="5" damping="0.5">
+      <joint joint="shoulder" coef="1"/>
+      <joint joint="elbow" coef="-1"/>
+    </fixed>
+  </tendon>
+
+  <actuator>
+    <position name="flex" tendon="flexor" kp="40"/>
+  </actuator>
+</mujoco>

--- a/genesis/constants.py
+++ b/genesis/constants.py
@@ -39,6 +39,21 @@ class EQUALITY_TYPE(IntEnum):
     CONNECT = 0
     WELD = 1
     JOINT = 2
+    TENDON = 3
+
+
+# Kind of tendon (fixed = linear joint coupling; spatial = geometric path through sites/geoms).
+class TENDON_TYPE(IntEnum):
+    FIXED = 0
+    SPATIAL = 1
+
+
+# Type of a spatial-tendon wrap-path element (compact remap of MuJoCo's mjtWrap).
+class WRAP_TYPE(IntEnum):
+    SITE = 0
+    PULLEY = 1
+    SPHERE = 2
+    CYLINDER = 3
 
 
 class CTRL_MODE(IntEnum):

--- a/genesis/engine/entities/rigid_entity/__init__.py
+++ b/genesis/engine/entities/rigid_entity/__init__.py
@@ -2,3 +2,5 @@ from .rigid_entity import KinematicEntity, RigidEntity
 from .rigid_geom import RigidGeom, RigidVisGeom
 from .rigid_joint import RigidJoint
 from .rigid_link import RigidLink
+from .rigid_site import RigidSite
+from .rigid_tendon import RigidTendon

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -27,6 +27,8 @@ from ..base_entity import Entity
 from .rigid_equality import RigidEquality
 from .rigid_geom import RigidGeom
 from .rigid_joint import RigidJoint
+from .rigid_site import RigidSite
+from .rigid_tendon import RigidTendon
 from .rigid_link import (
     GeomInertialInfo,
     KinematicLink,
@@ -199,7 +201,7 @@ class KinematicEntity(Entity):
             if isinstance(morph, (gs.morphs.URDF, gs.morphs.MJCF)):
                 # Parse variant scene file
                 morph._enable_mujoco_compatibility = self._morph._enable_mujoco_compatibility
-                v_l_infos, v_links_j_infos, v_links_g_infos, _ = self._parse_scene(morph, self._surface)
+                v_l_infos, v_links_j_infos, v_links_g_infos, _, _, _ = self._parse_scene(morph, self._surface)
 
                 # Validate that the variant has the same joint structure as the primary
                 if len(v_l_infos) != n_links:
@@ -627,18 +629,18 @@ class KinematicEntity(Entity):
         # initialized undetermined physics parameters.
         if isinstance(morph, gs.morphs.MJCF):
             # Mujoco's unified MJCF+URDF parser systematically for MJCF files
-            l_infos, links_j_infos, links_g_infos, eqs_info = mju.parse_xml(morph, surface)
+            l_infos, links_j_infos, links_g_infos, eqs_info, tendons_info, sites_info = mju.parse_xml(morph, surface)
         elif isinstance(morph, (gs.morphs.URDF, gs.morphs.Drone)):
             # Custom "legacy" URDF parser for loading geometries (visual and collision) and equality constraints.
             # This is necessary because Mujoco cannot parse visual geometries (meshes) reliably for URDF.
-            l_infos, links_j_infos, links_g_infos, eqs_info = uu.parse_urdf(morph, surface)
+            l_infos, links_j_infos, links_g_infos, eqs_info, tendons_info, sites_info = uu.parse_urdf(morph, surface)
 
             # Mujoco's unified MJCF+URDF parser for only link, joints, and collision geometries properties
             morph_ = morph.model_copy(update=dict(visualization=False))
             try:
                 # Mujoco's unified MJCF+URDF parser for URDF files.
                 # Note that Mujoco URDF parser completely ignores equality constraints.
-                l_infos_mj, links_j_infos_mj, links_g_infos_mj, _ = mju.parse_xml(morph_, surface)
+                l_infos_mj, links_j_infos_mj, links_g_infos_mj, _, _, _ = mju.parse_xml(morph_, surface)
 
                 # Unset link inertial properties that are actually undefined to force recomputation by genesis
                 if not morph._enable_mujoco_compatibility:
@@ -700,7 +702,9 @@ class KinematicEntity(Entity):
             from genesis.utils.usd import parse_usd_rigid_entity
 
             # Unified parser handles both articulations and rigid bodies
-            l_infos, links_j_infos, links_g_infos, eqs_info = parse_usd_rigid_entity(morph, surface)
+            l_infos, links_j_infos, links_g_infos, eqs_info, tendons_info, sites_info = parse_usd_rigid_entity(
+                morph, surface
+            )
 
         # Make sure that the inertia matrix of all links is valid
         if not morph.recompute_inertia:
@@ -911,10 +915,10 @@ class KinematicEntity(Entity):
         # Exclude joints with 0 dofs to align with Mujoco
         links_j_infos = [[j_info for j_info in link_j_infos if j_info["n_dofs"] > 0] for link_j_infos in links_j_infos]
 
-        return l_infos, links_j_infos, links_g_infos, eqs_info
+        return l_infos, links_j_infos, links_g_infos, eqs_info, tendons_info, sites_info
 
     def _load_scene(self, morph, surface):
-        l_infos, links_j_infos, links_g_infos, _eqs_info = self._parse_scene(morph, surface)
+        l_infos, links_j_infos, links_g_infos, _eqs_info, _tendons_info, _sites_info = self._parse_scene(morph, surface)
 
         # Add (link, joints, geoms) tuples sequentially
         for l_info, link_j_infos, link_g_infos in zip(l_infos, links_j_infos, links_g_infos):
@@ -2345,6 +2349,8 @@ class RigidEntity(KinematicEntity):
         custom_vvert_start=0,
         custom_vface_start=0,
         equality_start=0,
+        tendon_start=0,
+        site_start=0,
         visualize_contact: bool = False,
         morph_heterogeneous: list[Morph] | None = None,
         name: str | None = None,
@@ -2357,6 +2363,8 @@ class RigidEntity(KinematicEntity):
         self._free_verts_state_start = free_verts_state_start
         self._fixed_verts_state_start = fixed_verts_state_start
         self._equality_start = equality_start
+        self._tendon_start = tendon_start
+        self._site_start = site_start
         self._free_verts_idx_local = torch.tensor([], dtype=gs.tc_int, device=gs.device)
         self._fixed_verts_idx_local = torch.tensor([], dtype=gs.tc_int, device=gs.device)
         self._visualize_contact: bool = visualize_contact
@@ -2471,6 +2479,8 @@ class RigidEntity(KinematicEntity):
 
     def _load_model(self):
         self._equalities = gs.List()
+        self._tendons = gs.List()
+        self._sites = gs.List()
         self._requires_jac_and_IK = self._morph.requires_jac_and_IK
         self._is_local_collision_mask = isinstance(self._morph, gs.morphs.MJCF)
 
@@ -2479,7 +2489,7 @@ class RigidEntity(KinematicEntity):
     def _load_scene(self, morph, surface):
         from genesis.engine.couplers import IPCCoupler
 
-        l_infos, links_j_infos, links_g_infos, eqs_info = self._parse_scene(morph, surface)
+        l_infos, links_j_infos, links_g_infos, eqs_info, tendons_info, sites_info = self._parse_scene(morph, surface)
 
         # Make sure that the entity is not object
         if (
@@ -2493,7 +2503,37 @@ class RigidEntity(KinematicEntity):
         for l_info, link_j_infos, link_g_infos in zip(l_infos, links_j_infos, links_g_infos):
             self._add_by_info(l_info, link_j_infos, link_g_infos, morph, surface)
 
-        # Add equality constraints sequentially
+        # Add sites (persistent frames used by spatial tendons) sequentially
+        for s_info in sites_info:
+            self._add_site(
+                name=s_info["name"],
+                body_name=s_info["body_name"],
+                pos=s_info["pos"],
+                quat=s_info["quat"],
+            )
+
+        # Add tendons (fixed + spatial) sequentially. Must precede equalities so tendon-tendon equalities resolve.
+        for t_info in tendons_info:
+            self._add_tendon(
+                name=t_info["name"],
+                kind=t_info["kind"],
+                members=t_info["members"],
+                wraps=t_info["wraps"],
+                stiffness=t_info["stiffness"],
+                damping=t_info["damping"],
+                springlength=t_info["springlength"],
+                frictionloss=t_info["frictionloss"],
+                limited=t_info["limited"],
+                limit=t_info["limit"],
+                sol_params=t_info["sol_params"],
+                sol_params_limit=t_info["sol_params_limit"],
+                act_gain=t_info["act_gain"],
+                act_bias=t_info["act_bias"],
+                force_range=t_info["force_range"],
+                length0=t_info["length0"],
+            )
+
+        # Add equality constraints sequentially (may reference tendons added above)
         for eq_info in eqs_info:
             self._add_equality(
                 name=eq_info["name"],
@@ -2670,8 +2710,12 @@ class RigidEntity(KinematicEntity):
                 obj_id = self.get_joint(obj_name).idx
             elif type == gs.EQUALITY_TYPE.WELD:
                 obj_id = self.get_link(obj_name).idx
+            elif type == gs.EQUALITY_TYPE.TENDON:
+                obj_id = self.get_tendon(obj_name).idx
             else:
-                gs.raise_exception(f"Equality type {type} not supported. Only CONNECT, JOINT, and WELD are supported.")
+                gs.raise_exception(
+                    f"Equality type {type} not supported. Only CONNECT, JOINT, WELD, and TENDON are supported."
+                )
             objs_id.append(obj_id)
 
         equality = RigidEquality(
@@ -2686,6 +2730,60 @@ class RigidEntity(KinematicEntity):
         )
         self._equalities.append(equality)
         return equality
+
+    def _add_site(self, name, body_name, pos, quat):
+        site = RigidSite(
+            entity=self,
+            name=name,
+            idx=self.n_sites + self._site_start,
+            link_name=body_name,
+            pos=pos,
+            quat=quat,
+        )
+        self._sites.append(site)
+        return site
+
+    def _add_tendon(
+        self,
+        name,
+        kind,
+        members,
+        wraps,
+        stiffness,
+        damping,
+        springlength,
+        frictionloss,
+        limited,
+        limit,
+        sol_params,
+        sol_params_limit,
+        act_gain,
+        act_bias,
+        force_range,
+        length0,
+    ):
+        tendon = RigidTendon(
+            entity=self,
+            name=name,
+            idx=self.n_tendons + self._tendon_start,
+            kind=kind,
+            members=members,
+            wraps=wraps,
+            stiffness=stiffness,
+            damping=damping,
+            springlength=springlength,
+            frictionloss=frictionloss,
+            limited=limited,
+            limit=limit,
+            sol_params=sol_params,
+            sol_params_limit=sol_params_limit,
+            act_gain=act_gain,
+            act_bias=act_bias,
+            force_range=force_range,
+            length0=length0,
+        )
+        self._tendons.append(tendon)
+        return tendon
 
     # ------------------------------------------------------------------------------------
     # --------------------------------- Jacobian & IK ------------------------------------
@@ -4653,6 +4751,91 @@ class RigidEntity(KinematicEntity):
     def equalities(self):
         """The list of equality constraints (`RigidEquality`) in the entity."""
         return self._equalities
+
+    @property
+    def n_tendons(self):
+        """The number of (fixed) tendons in the entity."""
+        return len(self._tendons)
+
+    @property
+    def tendon_start(self):
+        """The index of the entity's first RigidTendon in the scene."""
+        return self._tendon_start
+
+    @property
+    def tendon_end(self):
+        """The index of the entity's last RigidTendon in the scene *plus one*."""
+        return self._tendon_start + self.n_tendons
+
+    @property
+    def tendons(self):
+        """The list of (fixed) tendons (`RigidTendon`) in the entity."""
+        return self._tendons
+
+    def get_tendon(self, name=None, uid=None):
+        """Get a tendon of the entity by name or uid."""
+        if name is not None:
+            for tendon in self._tendons:
+                if tendon.name == name:
+                    return tendon
+            gs.raise_exception(f"Tendon with name '{name}' not found.")
+        elif uid is not None:
+            for tendon in self._tendons:
+                if str(uid) in str(tendon.uid):
+                    return tendon
+            gs.raise_exception(f"Tendon with uid '{uid}' not found.")
+        gs.raise_exception("Either `name` or `uid` must be provided.")
+
+    @property
+    def n_sites(self):
+        """The number of sites in the entity."""
+        return len(self._sites)
+
+    @property
+    def site_start(self):
+        """The index of the entity's first RigidSite in the scene."""
+        return self._site_start
+
+    @property
+    def site_end(self):
+        """The index of the entity's last RigidSite in the scene *plus one*."""
+        return self._site_start + self.n_sites
+
+    @property
+    def sites(self):
+        """The list of sites (`RigidSite`) in the entity."""
+        return self._sites
+
+    def get_site(self, name):
+        """Get a site of the entity by name."""
+        for site in self._sites:
+            if site.name == name:
+                return site
+        gs.raise_exception(f"Site with name '{name}' not found.")
+
+    def draw_debug_tendons(self, color=(0.9, 0.2, 0.2, 1.0), radius=0.004, env_idx=0):
+        """Draw the world-space path of each spatial tendon as a polyline for debug visualization.
+
+        Returns the created debug objects (pass them to `scene.clear_debug_object`, or call `scene.clear_debug_objects`,
+        before redrawing each step). Fixed tendons have no geometric path and are skipped.
+        """
+        if self.n_tendons == 0:
+            return []
+        path_pos = qd_to_numpy(self._solver.tendons_state.path_pos, transpose=True)  # (B, n_tendons, max_path, 3)
+        path_num = qd_to_numpy(self._solver.tendons_state.path_num, transpose=True)  # (B, n_tendons)
+        nodes = []
+        for tendon in self._tendons:
+            n_points = int(path_num[env_idx, tendon.idx])
+            for k in range(n_points - 1):
+                nodes.append(
+                    self._solver.scene.draw_debug_line(
+                        path_pos[env_idx, tendon.idx, k],
+                        path_pos[env_idx, tendon.idx, k + 1],
+                        radius=radius,
+                        color=color,
+                    )
+                )
+        return nodes
 
     @property
     def is_free(self) -> bool:

--- a/genesis/engine/entities/rigid_entity/rigid_site.py
+++ b/genesis/engine/entities/rigid_entity/rigid_site.py
@@ -1,0 +1,67 @@
+import numpy as np
+
+import genesis as gs
+from genesis.repr_base import RBC
+
+
+class RigidSite(RBC):
+    """
+    Site for rigid body entities.
+
+    A site is a massless frame rigidly attached to a link, used as a reference point (e.g. a via-point or anchor for
+    spatial tendons and equality constraints). Its world pose is recomputed each step from the owning link's transform.
+    """
+
+    def __init__(self, entity, name, idx, link_name, pos, quat):
+        self._name = name
+        self._entity = entity
+        self._solver = entity.solver
+
+        self._uid = gs.UID()
+        self._idx = idx
+        self._link_name = link_name
+        self._pos = np.asarray(pos, dtype=gs.np_float)
+        self._quat = np.asarray(quat, dtype=gs.np_float)
+
+    @property
+    def uid(self):
+        """Returns the unique id of the site."""
+        return self._uid
+
+    @property
+    def name(self):
+        """Returns the name of the site."""
+        return self._name
+
+    @property
+    def entity(self):
+        """Returns the entity that the site belongs to."""
+        return self._entity
+
+    @property
+    def idx(self):
+        """Returns the global index of the site in the rigid solver."""
+        return self._idx
+
+    @property
+    def idx_local(self):
+        """Returns the local index of the site in the entity."""
+        return self._idx - self._entity._site_start
+
+    @property
+    def link_name(self):
+        """Returns the name of the link the site is attached to."""
+        return self._link_name
+
+    @property
+    def pos(self):
+        """Returns the site's local position in the owning link frame."""
+        return self._pos
+
+    @property
+    def quat(self):
+        """Returns the site's local orientation in the owning link frame."""
+        return self._quat
+
+    def _repr_brief(self):
+        return f"{self.__repr_name__()}, idx: {self.idx}, name: '{self.name}'"

--- a/genesis/engine/entities/rigid_entity/rigid_tendon.py
+++ b/genesis/engine/entities/rigid_entity/rigid_tendon.py
@@ -1,0 +1,138 @@
+import numpy as np
+
+import genesis as gs
+from genesis.repr_base import RBC
+
+
+class RigidTendon(RBC):
+    """
+    Fixed tendon for rigid body entities.
+
+    A fixed tendon defines a scalar length ``L = sum_i coef_i * qpos_i`` over its member joints, coupling them
+    through passive spring/damping, length limits, frictionloss, and/or an actuator transmission. Because the length
+    is a linear combination of joint positions, the moment arm w.r.t. each member DOF is the constant coefficient
+    ``coef_i``. Spatial tendons (site/geom routing) are not supported.
+    """
+
+    def __init__(
+        self,
+        entity,
+        name,
+        idx,
+        kind,
+        members,
+        wraps,
+        stiffness,
+        damping,
+        springlength,
+        frictionloss,
+        limited,
+        limit,
+        sol_params,
+        sol_params_limit,
+        act_gain,
+        act_bias,
+        force_range,
+        length0=0.0,
+    ):
+        self._name = name
+        self._entity = entity
+        self._solver = entity.solver
+
+        self._uid = gs.UID()
+        self._idx = idx
+        self._kind = kind
+
+        # members: list of (joint_name, coef)  [FIXED tendons]
+        self._members = tuple(members)
+        # wraps: ordered list of dicts describing the spatial path  [SPATIAL tendons]
+        self._wraps = tuple(wraps)
+        self._stiffness = float(stiffness)
+        self._damping = float(damping)
+        self._springlength = np.asarray(springlength, dtype=gs.np_float)
+        self._frictionloss = float(frictionloss)
+        self._limited = bool(limited)
+        self._limit = np.asarray(limit, dtype=gs.np_float)
+        self._sol_params = np.asarray(sol_params, dtype=gs.np_float)
+        self._sol_params_limit = np.asarray(sol_params_limit, dtype=gs.np_float)
+        self._act_gain = float(act_gain)
+        self._act_bias = np.asarray(act_bias, dtype=gs.np_float)
+        self._force_range = np.asarray(force_range, dtype=gs.np_float)
+        self._length0 = float(length0)
+
+    # ------------------------------------------------------------------------------------
+    # ------------------------------------ control ---------------------------------------
+    # ------------------------------------------------------------------------------------
+
+    def control_position(self, pos, envs_idx=None):
+        """Set the position (target length) control target for this tendon's actuator."""
+        self._solver.control_tendons_position(pos, tendons_idx=self._idx, envs_idx=envs_idx)
+
+    def control_velocity(self, vel, envs_idx=None):
+        """Set the velocity control target for this tendon's actuator."""
+        self._solver.control_tendons_velocity(vel, tendons_idx=self._idx, envs_idx=envs_idx)
+
+    def control_force(self, force, envs_idx=None):
+        """Set the direct force control target for this tendon's actuator."""
+        self._solver.control_tendons_force(force, tendons_idx=self._idx, envs_idx=envs_idx)
+
+    def get_length(self, envs_idx=None):
+        """Return the current tendon length ``L = sum_i coef_i * qpos_i``."""
+        return self._solver.get_tendons_length(tendons_idx=self._idx, envs_idx=envs_idx)
+
+    # ------------------------------------------------------------------------------------
+    # ----------------------------------- properties -------------------------------------
+    # ------------------------------------------------------------------------------------
+
+    @property
+    def uid(self):
+        """Returns the unique id of the tendon."""
+        return self._uid
+
+    @property
+    def name(self):
+        """Returns the name of the tendon."""
+        return self._name
+
+    @property
+    def entity(self):
+        """Returns the entity that the tendon belongs to."""
+        return self._entity
+
+    @property
+    def solver(self):
+        """The RigidSolver object that the tendon belongs to."""
+        return self._solver
+
+    @property
+    def idx(self):
+        """Returns the global index of the tendon in the rigid solver."""
+        return self._idx
+
+    @property
+    def idx_local(self):
+        """Returns the local index of the tendon in the entity."""
+        return self._idx - self._entity._tendon_start
+
+    @property
+    def kind(self):
+        """Returns the tendon kind (`gs.TENDON_TYPE.FIXED` or `gs.TENDON_TYPE.SPATIAL`)."""
+        return self._kind
+
+    @property
+    def members(self):
+        """Returns the tuple of ``(joint_name, coef)`` members of the fixed tendon."""
+        return self._members
+
+    @property
+    def wraps(self):
+        """Returns the ordered spatial wrap path (tuple of element dicts) for a spatial tendon."""
+        return self._wraps
+
+    @property
+    def is_built(self):
+        """Whether the rigid entity this tendon belongs to is built."""
+        return self.entity.is_built
+
+    def _repr_brief(self):
+        return f"{self.__repr_name__()}, idx: {self.idx}, name: '{self.name}'"

--- a/genesis/engine/solvers/rigid/abd/accessor.py
+++ b/genesis/engine/solvers/rigid/abd/accessor.py
@@ -1026,6 +1026,68 @@ def kernel_control_dofs_position_velocity(
 
 
 @qd.kernel(fastcache=True)
+def kernel_control_tendons_force(
+    force: qd.types.ndarray(),
+    tendons_idx: qd.types.ndarray(),
+    envs_idx: qd.types.ndarray(),
+    tendons_state: array_class.TendonsState,
+    static_rigid_sim_config: qd.template(),
+):
+    qd.loop_config(serialize=qd.static(static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL))
+    for i_t_, i_b_ in qd.ndrange(tendons_idx.shape[0], envs_idx.shape[0]):
+        i_t = tendons_idx[i_t_]
+        i_b = envs_idx[i_b_]
+        tendons_state.ctrl_mode[i_t, i_b] = gs.CTRL_MODE.FORCE
+        tendons_state.ctrl_force[i_t, i_b] = force[i_b_, i_t_]
+
+
+@qd.kernel(fastcache=True)
+def kernel_control_tendons_velocity(
+    velocity: qd.types.ndarray(),
+    tendons_idx: qd.types.ndarray(),
+    envs_idx: qd.types.ndarray(),
+    tendons_state: array_class.TendonsState,
+    static_rigid_sim_config: qd.template(),
+):
+    qd.loop_config(serialize=qd.static(static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL))
+    for i_t_, i_b_ in qd.ndrange(tendons_idx.shape[0], envs_idx.shape[0]):
+        i_t = tendons_idx[i_t_]
+        i_b = envs_idx[i_b_]
+        tendons_state.ctrl_mode[i_t, i_b] = gs.CTRL_MODE.VELOCITY
+        tendons_state.ctrl_vel[i_t, i_b] = velocity[i_b_, i_t_]
+
+
+@qd.kernel(fastcache=True)
+def kernel_control_tendons_position(
+    position: qd.types.ndarray(),
+    tendons_idx: qd.types.ndarray(),
+    envs_idx: qd.types.ndarray(),
+    tendons_state: array_class.TendonsState,
+    static_rigid_sim_config: qd.template(),
+):
+    qd.loop_config(serialize=qd.static(static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL))
+    for i_t_, i_b_ in qd.ndrange(tendons_idx.shape[0], envs_idx.shape[0]):
+        i_t = tendons_idx[i_t_]
+        i_b = envs_idx[i_b_]
+        tendons_state.ctrl_mode[i_t, i_b] = gs.CTRL_MODE.POSITION
+        tendons_state.ctrl_pos[i_t, i_b] = position[i_b_, i_t_]
+        tendons_state.ctrl_vel[i_t, i_b] = 0.0
+
+
+@qd.kernel(fastcache=True)
+def kernel_get_tendons_length(
+    tensor: qd.types.ndarray(),
+    tendons_idx: qd.types.ndarray(),
+    envs_idx: qd.types.ndarray(),
+    tendons_state: array_class.TendonsState,
+    static_rigid_sim_config: qd.template(),
+):
+    qd.loop_config(serialize=qd.static(static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL))
+    for i_t_, i_b_ in qd.ndrange(tendons_idx.shape[0], envs_idx.shape[0]):
+        tensor[i_b_, i_t_] = tendons_state.length[tendons_idx[i_t_], envs_idx[i_b_]]
+
+
+@qd.kernel(fastcache=True)
 def kernel_get_links_vel(
     tensor: qd.types.ndarray(),
     links_idx: qd.types.ndarray(),

--- a/genesis/engine/solvers/rigid/abd/forward_dynamics.py
+++ b/genesis/engine/solvers/rigid/abd/forward_dynamics.py
@@ -141,6 +141,10 @@ def func_forward_dynamics(
     entities_state: array_class.EntitiesState,
     entities_info: array_class.EntitiesInfo,
     geoms_state: array_class.GeomsState,
+    geoms_info: array_class.GeomsInfo,
+    sites_info: array_class.SitesInfo,
+    tendons_info: array_class.TendonsInfo,
+    tendons_state: array_class.TendonsState,
     rigid_global_info: array_class.RigidGlobalInfo,
     static_rigid_sim_config: qd.template(),
     island_state: array_class.IslandState,
@@ -166,6 +170,18 @@ def func_forward_dynamics(
         static_rigid_sim_config=static_rigid_sim_config,
         is_backward=is_backward,
     )
+    func_compute_tendon_length_moment(
+        tendons_info=tendons_info,
+        tendons_state=tendons_state,
+        sites_info=sites_info,
+        dofs_state=dofs_state,
+        links_info=links_info,
+        links_state=links_state,
+        geoms_state=geoms_state,
+        geoms_info=geoms_info,
+        rigid_global_info=rigid_global_info,
+        static_rigid_sim_config=static_rigid_sim_config,
+    )
     func_torque_and_passive_force(
         entities_state=entities_state,
         entities_info=entities_info,
@@ -175,6 +191,8 @@ def func_forward_dynamics(
         links_info=links_info,
         joints_info=joints_info,
         geoms_state=geoms_state,
+        tendons_info=tendons_info,
+        tendons_state=tendons_state,
         rigid_global_info=rigid_global_info,
         static_rigid_sim_config=static_rigid_sim_config,
         island_state=island_state,
@@ -225,6 +243,10 @@ def kernel_forward_dynamics(
     entities_state: array_class.EntitiesState,
     entities_info: array_class.EntitiesInfo,
     geoms_state: array_class.GeomsState,
+    geoms_info: array_class.GeomsInfo,
+    sites_info: array_class.SitesInfo,
+    tendons_info: array_class.TendonsInfo,
+    tendons_state: array_class.TendonsState,
     rigid_global_info: array_class.RigidGlobalInfo,
     static_rigid_sim_config: qd.template(),
     island_state: array_class.IslandState,
@@ -238,6 +260,10 @@ def kernel_forward_dynamics(
         entities_state=entities_state,
         entities_info=entities_info,
         geoms_state=geoms_state,
+        geoms_info=geoms_info,
+        sites_info=sites_info,
+        tendons_info=tendons_info,
+        tendons_state=tendons_state,
         rigid_global_info=rigid_global_info,
         static_rigid_sim_config=static_rigid_sim_config,
         island_state=island_state,
@@ -274,6 +300,510 @@ def func_vel_at_point(pos_world, link_idx, i_b, links_state: array_class.LinksSt
     vel_rot = links_state.cd_ang[link_idx, i_b].cross(pos_world - links_state.root_COM[link_idx, i_b])
     vel_lin = links_state.cd_vel[link_idx, i_b]
     return vel_rot + vel_lin
+
+
+@qd.func
+def func_add_point_moment(
+    i_t,
+    i_b,
+    body_link,
+    point,
+    u,
+    scale,
+    tendons_state: array_class.TendonsState,
+    dofs_state: array_class.DofsState,
+    links_info: array_class.LinksInfo,
+    links_state: array_class.LinksState,
+    static_rigid_sim_config: qd.template(),
+):
+    # Accumulate scale * u . Jp[i_d] into the tendon moment for every DOF on the parent chain of `body_link`, where
+    # Jp[i_d] = cdof_vel[i_d] + cdof_ang[i_d] x (point - root_COM) is the translational Jacobian of `point` w.r.t. i_d.
+    root_com = links_state.root_COM[body_link, i_b]
+    i_l = body_link
+    while i_l > -1:
+        I_l = [i_l, i_b] if qd.static(static_rigid_sim_config.batch_links_info) else i_l
+        for i_d in range(links_info.dof_start[I_l], links_info.dof_end[I_l]):
+            jp = dofs_state.cdof_vel[i_d, i_b] + dofs_state.cdof_ang[i_d, i_b].cross(point - root_com)
+            tendons_state.moment[i_t, i_d, i_b] = tendons_state.moment[i_t, i_d, i_b] + scale * u.dot(jp)
+        i_l = links_info.parent_idx[I_l]
+
+
+@qd.func
+def func_site_world_pos(site_id, i_b, sites_info: array_class.SitesInfo, links_state: array_class.LinksState):
+    body = sites_info.link_idx[site_id]
+    return links_state.pos[body, i_b] + gu.qd_transform_by_quat(sites_info.pos[site_id], links_state.quat[body, i_b])
+
+
+@qd.func
+def func_add_segment(
+    i_t,
+    i_b,
+    p0,
+    b0,
+    p1,
+    b1,
+    inv_div,
+    eps,
+    tendons_state: array_class.TendonsState,
+    dofs_state: array_class.DofsState,
+    links_info: array_class.LinksInfo,
+    links_state: array_class.LinksState,
+    static_rigid_sim_config: qd.template(),
+):
+    # Accumulate one path segment p0(body b0) -> p1(body b1): add its length/divisor to the return value and its moment
+    # contribution (only when the endpoints are on different bodies).
+    seg = p1 - p0
+    seglen = seg.norm()
+    if b0 != b1 and seglen > eps:
+        u = seg / seglen
+        func_add_point_moment(
+            i_t, i_b, b1, p1, u, inv_div, tendons_state, dofs_state, links_info, links_state, static_rigid_sim_config
+        )
+        func_add_point_moment(
+            i_t, i_b, b0, p0, u, -inv_div, tendons_state, dofs_state, links_info, links_state, static_rigid_sim_config
+        )
+    return seglen * inv_div
+
+
+# ------------------------------------------------------------------------------------------------------------------
+# Tendon geom-wrapping geometry (port of MuJoCo's mju_wrap / wrap_circle / wrap_inside; see engine_util_misc.c).
+# All 2D routines operate in the wrap object's local frame. Return value packs [wlen, p0x, p0y, p1x, p1y]; wlen < 0
+# means "no wrap". The 3D func_wrap returns [wlen, w0(3), w1(3)] in world coordinates.
+# ------------------------------------------------------------------------------------------------------------------
+@qd.func
+def func_normalize3(v):
+    n = qd.sqrt(v.dot(v))
+    return v / qd.max(n, gs.qd_float(1e-15))
+
+
+@qd.func
+def func_mat_vec3(R, v):
+    # R @ v for a 3x3 matrix and 3-vector.
+    return qd.Vector(
+        [
+            R[0, 0] * v[0] + R[0, 1] * v[1] + R[0, 2] * v[2],
+            R[1, 0] * v[0] + R[1, 1] * v[1] + R[1, 2] * v[2],
+            R[2, 0] * v[0] + R[2, 1] * v[1] + R[2, 2] * v[2],
+        ]
+    )
+
+
+@qd.func
+def func_matT_vec3(R, v):
+    # R^T @ v for a 3x3 matrix and 3-vector.
+    return qd.Vector(
+        [
+            R[0, 0] * v[0] + R[1, 0] * v[1] + R[2, 0] * v[2],
+            R[0, 1] * v[0] + R[1, 1] * v[1] + R[2, 1] * v[2],
+            R[0, 2] * v[0] + R[1, 2] * v[1] + R[2, 2] * v[2],
+        ]
+    )
+
+
+@qd.func
+def func_is_intersect(p1x, p1y, p2x, p2y, p3x, p3y, p4x, p4y):
+    # Whether segment (p1->p2) intersects segment (p3->p4) in 2D.
+    result = False
+    det = (p4y - p3y) * (p2x - p1x) - (p4x - p3x) * (p2y - p1y)
+    if qd.abs(det) >= 1e-15:
+        a = ((p4x - p3x) * (p1y - p3y) - (p4y - p3y) * (p1x - p3x)) / det
+        b = ((p2x - p1x) * (p1y - p3y) - (p2y - p1y) * (p1x - p3x)) / det
+        result = (a >= 0.0) and (a <= 1.0) and (b >= 0.0) and (b <= 1.0)
+    return result
+
+
+@qd.func
+def func_length_circle(p0x, p0y, p1x, p1y, ind, radius):
+    n0 = qd.sqrt(p0x * p0x + p0y * p0y)
+    n1 = qd.sqrt(p1x * p1x + p1y * p1y)
+    d0x = p0x / n0
+    d0y = p0y / n0
+    d1x = p1x / n1
+    d1y = p1y / n1
+    angle = qd.acos(qd.math.clamp(d0x * d1x + d0y * d1y, gs.qd_float(-1.0), gs.qd_float(1.0)))
+    cross = p0y * p1x - p0x * p1y
+    if (cross > 0.0 and ind == 1) or (cross < 0.0 and ind == 0):
+        angle = 2.0 * qd.math.pi - angle
+    return radius * angle
+
+
+@qd.func
+def func_wrap_circle(e0, e1, e2, e3, has_side, sx, sy, radius):
+    # 2D circle wrap. `has_side` toggles side-point preference (the stateless MuJoCo sidesite mechanism); otherwise the
+    # shortest wrap is chosen. Returns [wlen, p0x, p0y, p1x, p1y]; wlen < 0 = no wrap.
+    res = qd.Vector([gs.qd_float(-1.0), gs.qd_float(0.0), gs.qd_float(0.0), gs.qd_float(0.0), gs.qd_float(0.0)])
+    sqlen0 = e0 * e0 + e1 * e1
+    sqlen1 = e2 * e2 + e3 * e3
+    sqrad = radius * radius
+    difx = e2 - e0
+    dify = e3 - e1
+    dd = difx * difx + dify * dify
+
+    valid = True
+    if sqlen0 < sqrad or sqlen1 < sqrad or radius < 1e-15 or dd < 1e-15:
+        valid = False
+
+    if valid:
+        a = -(difx * e0 + dify * e1) / dd
+        a = qd.math.clamp(a, gs.qd_float(0.0), gs.qd_float(1.0))
+        tmpx = a * difx + e0
+        tmpy = a * dify + e1
+        if (tmpx * tmpx + tmpy * tmpy) > sqrad and ((not has_side) or (sx * tmpx + sy * tmpy) >= 0.0):
+            valid = False
+
+    if valid:
+        sqrt0 = qd.sqrt(qd.max(sqlen0 - sqrad, gs.qd_float(0.0)))
+        sqrt1 = qd.sqrt(qd.max(sqlen1 - sqrad, gs.qd_float(0.0)))
+
+        best_good = gs.qd_float(-1e30)
+        best_i = 0
+        best = qd.Vector([gs.qd_float(0.0), gs.qd_float(0.0), gs.qd_float(0.0), gs.qd_float(0.0)])
+        for i in range(2):
+            sgn = gs.qd_float(1.0) if i == 0 else gs.qd_float(-1.0)
+            s00 = (e0 * sqrad + sgn * radius * e1 * sqrt0) / sqlen0
+            s01 = (e1 * sqrad - sgn * radius * e0 * sqrt0) / sqlen0
+            s10 = (e2 * sqrad - sgn * radius * e3 * sqrt1) / sqlen1
+            s11 = (e3 * sqrad + sgn * radius * e2 * sqrt1) / sqlen1
+
+            good = gs.qd_float(0.0)
+            if has_side:
+                tx = s00 + s10
+                ty = s01 + s11
+                tn = qd.sqrt(tx * tx + ty * ty)
+                good = (tx / tn) * sx + (ty / tn) * sy
+            else:
+                tx = s00 - s10
+                ty = s01 - s11
+                good = -(tx * tx + ty * ty)
+            if func_is_intersect(e0, e1, s00, s01, e2, e3, s10, s11):
+                good = gs.qd_float(-10000.0)
+            if good > best_good:
+                best_good = good
+                best_i = i
+                best = qd.Vector([s00, s01, s10, s11])
+
+        if func_is_intersect(e0, e1, best[0], best[1], e2, e3, best[2], best[3]):
+            valid = False
+        else:
+            wlen = func_length_circle(best[0], best[1], best[2], best[3], best_i, radius)
+            res = qd.Vector([wlen, best[0], best[1], best[2], best[3]])
+
+    return res
+
+
+@qd.func
+def func_wrap_inside(e0, e1, e2, e3, radius):
+    # 2D inside wrap (Newton iteration). Returns [wlen(=0 on success, -1 no wrap), p0x, p0y, p1x, p1y].
+    res = qd.Vector([gs.qd_float(-1.0), gs.qd_float(0.0), gs.qd_float(0.0), gs.qd_float(0.0), gs.qd_float(0.0)])
+    maxiter = 20
+    zinit = gs.qd_float(1.0 - 1e-7)
+    tolerance = gs.qd_float(1e-6)
+
+    len0 = qd.sqrt(e0 * e0 + e1 * e1)
+    len1 = qd.sqrt(e2 * e2 + e3 * e3)
+    difx = e2 - e0
+    dify = e3 - e1
+    dd = difx * difx + dify * dify
+
+    valid = True
+    if len0 <= radius or len1 <= radius or radius < 1e-15 or len0 < 1e-15 or len1 < 1e-15:
+        valid = False
+    if valid and dd > 1e-15:
+        a = -(difx * e0 + dify * e1) / dd
+        if a > 0.0 and a < 1.0:
+            tx = e0 + a * difx
+            ty = e1 + a * dify
+            if qd.sqrt(tx * tx + ty * ty) <= radius:
+                valid = False
+
+    if valid:
+        A = radius / len0
+        B = radius / len1
+        cosG = (len0 * len0 + len1 * len1 - dd) / (2.0 * len0 * len1)
+        if cosG < -1.0 + 1e-15:
+            valid = False
+        elif cosG > 1.0 - 1e-15:
+            valid = False  # wlen 0 with default average handled below via no-op (treated as no wrap)
+
+    if valid:
+        # Default (numerical-failure) fallback point: normalized average, scaled to the radius.
+        px = 0.5 * (e0 + e2)
+        py = 0.5 * (e1 + e3)
+        pn = qd.sqrt(px * px + py * py)
+        px = radius * px / pn
+        py = radius * py / pn
+
+        A = radius / len0
+        B = radius / len1
+        cosG = (len0 * len0 + len1 * len1 - dd) / (2.0 * len0 * len1)
+        G = qd.acos(qd.math.clamp(cosG, gs.qd_float(-1.0), gs.qd_float(1.0)))
+
+        z = zinit
+        f = qd.asin(A * z) + qd.asin(B * z) - 2.0 * qd.asin(z) + G
+        converged = f <= 0.0
+        it = 0
+        while it < maxiter and qd.abs(f) > tolerance and converged:
+            df = (
+                A / qd.max(gs.qd_float(1e-15), qd.sqrt(1.0 - z * z * A * A))
+                + B / qd.max(gs.qd_float(1e-15), qd.sqrt(1.0 - z * z * B * B))
+                - 2.0 / qd.max(gs.qd_float(1e-15), qd.sqrt(1.0 - z * z))
+            )
+            if df > -1e-15:
+                converged = False
+            else:
+                z1 = z - f / df
+                if z1 > z:
+                    converged = False
+                else:
+                    z = z1
+                    f = qd.asin(A * z) + qd.asin(B * z) - 2.0 * qd.asin(z) + G
+                    if f > tolerance:
+                        converged = False
+            it += 1
+
+        if converged and it < maxiter:
+            # rotate vec (= a or b) by ang depending on sign of cross(a, b)
+            vx = e0
+            vy = e1
+            ang = qd.asin(z) - qd.asin(A * z)
+            if e0 * e3 - e1 * e2 <= 0.0:
+                vx = e2
+                vy = e3
+                ang = qd.asin(z) - qd.asin(B * z)
+            vn = qd.sqrt(vx * vx + vy * vy)
+            vx = vx / vn
+            vy = vy / vn
+            px = radius * (qd.cos(ang) * vx - qd.sin(ang) * vy)
+            py = radius * (qd.sin(ang) * vx + qd.cos(ang) * vy)
+
+        res = qd.Vector([gs.qd_float(0.0), px, py, px, py])
+
+    return res
+
+
+@qd.func
+def func_wrap(x0, x1, xpos, xmat, radius, is_cylinder, has_side, side):
+    # 3D tendon wrap around a sphere/cylinder geom. Returns [wlen, w0x, w0y, w0z, w1x, w1y, w1z]; wlen < 0 = no wrap.
+    out = qd.Vector([gs.qd_float(-1.0)] + [gs.qd_float(0.0)] * 6)
+
+    # map endpoints to the geom's local frame
+    p0 = func_matT_vec3(xmat, x0 - xpos)
+    p1 = func_matT_vec3(xmat, x1 - xpos)
+
+    valid = True
+    if qd.sqrt(p0.dot(p0)) < 1e-15 or qd.sqrt(p1.dot(p1)) < 1e-15:
+        valid = False
+    axis0 = qd.Vector([gs.qd_float(1.0), gs.qd_float(0.0), gs.qd_float(0.0)])
+    axis1 = qd.Vector([gs.qd_float(0.0), gs.qd_float(1.0), gs.qd_float(0.0)])
+    if valid:
+        # construct the 2D wrap frame
+        if not is_cylinder:
+            axis0 = func_normalize3(p0)
+            normal = p0.cross(p1)
+            nrm = qd.sqrt(normal.dot(normal))
+            if nrm < 1e-15:
+                # p0, p1 parallel: pick an alternative in-plane axis
+                i_max = 0
+                if qd.abs(axis0[1]) > qd.abs(axis0[0]) and qd.abs(axis0[1]) > qd.abs(axis0[2]):
+                    i_max = 1
+                if qd.abs(axis0[2]) > qd.abs(axis0[0]) and qd.abs(axis0[2]) > qd.abs(axis0[1]):
+                    i_max = 2
+                alt = qd.Vector([gs.qd_float(1.0), gs.qd_float(1.0), gs.qd_float(1.0)])
+                alt[i_max] = gs.qd_float(0.0)
+                normal = axis0.cross(alt)
+            normal = func_normalize3(normal)
+            axis1 = func_normalize3(normal.cross(axis0))
+
+        d0 = p0.dot(axis0)
+        d1 = p0.dot(axis1)
+        d2 = p1.dot(axis0)
+        d3 = p1.dot(axis1)
+
+        sx = gs.qd_float(0.0)
+        sy = gs.qd_float(0.0)
+        s_local = qd.Vector([gs.qd_float(0.0), gs.qd_float(0.0), gs.qd_float(0.0)])
+        if has_side:
+            s_local = func_matT_vec3(xmat, side - xpos)
+            sx = s_local.dot(axis0)
+            sy = s_local.dot(axis1)
+            sn = qd.sqrt(sx * sx + sy * sy)
+            sx = radius * sx / sn
+            sy = radius * sy / sn
+
+        wrap2d = func_wrap_circle(d0, d1, d2, d3, has_side, sx, sy, radius)
+        if has_side and s_local.norm() < radius:
+            wrap2d = func_wrap_inside(d0, d1, d2, d3, radius)
+
+        wlen = wrap2d[0]
+        if wlen < 0.0:
+            valid = False
+        else:
+            # reconstruct 3D wrap points in the local frame
+            res0 = axis0 * wrap2d[1] + axis1 * wrap2d[2]
+            res1 = axis0 * wrap2d[3] + axis1 * wrap2d[4]
+
+            if is_cylinder:
+                # interpolate the z (cylinder-axis) coordinate along the path and correct wlen for height
+                L0 = qd.sqrt((p0[0] - res0[0]) ** 2 + (p0[1] - res0[1]) ** 2)
+                L1 = qd.sqrt((p1[0] - res1[0]) ** 2 + (p1[1] - res1[1]) ** 2)
+                denom = L0 + wlen + L1
+                res0[2] = p0[2] + (p1[2] - p0[2]) * L0 / denom
+                res1[2] = p0[2] + (p1[2] - p0[2]) * (L0 + wlen) / denom
+                height = qd.abs(res1[2] - res0[2])
+                wlen = qd.sqrt(wlen * wlen + height * height)
+
+            w0 = func_mat_vec3(xmat, res0) + xpos
+            w1 = func_mat_vec3(xmat, res1) + xpos
+            out = qd.Vector([wlen, w0[0], w0[1], w0[2], w1[0], w1[1], w1[2]])
+
+    return out
+
+
+@qd.func
+def func_compute_tendon_length_moment(
+    tendons_info: array_class.TendonsInfo,
+    tendons_state: array_class.TendonsState,
+    sites_info: array_class.SitesInfo,
+    dofs_state: array_class.DofsState,
+    links_info: array_class.LinksInfo,
+    links_state: array_class.LinksState,
+    geoms_state: array_class.GeomsState,
+    geoms_info: array_class.GeomsInfo,
+    rigid_global_info: array_class.RigidGlobalInfo,
+    static_rigid_sim_config: qd.template(),
+):
+    EPS = rigid_global_info.EPS[None]
+    _B = dofs_state.ctrl_mode.shape[1]
+
+    qd.loop_config(serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL)
+    for i_t, i_b in qd.ndrange(qd.static(static_rigid_sim_config.n_tendons), _B):
+        n_mem = tendons_info.n_members[i_t]
+
+        # Reset the moment row (only the relevant DOFs are ever nonzero).
+        for k in range(n_mem):
+            tendons_state.moment[i_t, tendons_info.dof_idx[i_t, k], i_b] = gs.qd_float(0.0)
+
+        length = gs.qd_float(0.0)
+        path_n = 0  # number of recorded world path points (spatial tendons only; for debug visualization)
+        max_path = tendons_state.path_pos.shape[1]
+        if tendons_info.kind[i_t] == gs.TENDON_TYPE.FIXED:
+            for k in range(n_mem):
+                i_d = tendons_info.dof_idx[i_t, k]
+                coef = tendons_info.coef[i_t, k]
+                tendons_state.moment[i_t, i_d, i_b] = coef
+                length = length + coef * rigid_global_info.qpos[tendons_info.q_idx[i_t, k], i_b]
+        else:
+            divisor = gs.qd_float(1.0)
+            prev_valid = False
+            prev_pnt = qd.Vector.zero(gs.qd_float, 3)
+            prev_body = -1
+            n_w = tendons_info.n_wraps[i_t]
+            w = 0
+            while w < n_w:
+                wt = tendons_info.wrap_type[i_t, w]
+                if wt == gs.WRAP_TYPE.PULLEY:
+                    divisor = tendons_info.wrap_prm[i_t, w]
+                    prev_valid = False
+                    w = w + 1
+                elif wt == gs.WRAP_TYPE.SITE:
+                    site_id = tendons_info.wrap_objid[i_t, w]
+                    body = sites_info.link_idx[site_id]
+                    cur_pnt = func_site_world_pos(site_id, i_b, sites_info, links_state)
+
+                    # Emit the segment from the previous point to this site.
+                    if prev_valid:
+                        length = length + func_add_segment(
+                            i_t,
+                            i_b,
+                            prev_pnt,
+                            prev_body,
+                            cur_pnt,
+                            body,
+                            gs.qd_float(1.0) / divisor,
+                            EPS,
+                            tendons_state,
+                            dofs_state,
+                            links_info,
+                            links_state,
+                            static_rigid_sim_config,
+                        )
+                    prev_pnt = cur_pnt
+                    prev_body = body
+                    prev_valid = True
+                    if path_n < max_path:
+                        tendons_state.path_pos[i_t, path_n, i_b] = cur_pnt
+                        path_n = path_n + 1
+
+                    # Look ahead: a geom wrap element (site -> geom -> site) wraps this site to the next one.
+                    is_geom_next = False
+                    if w + 1 < n_w:
+                        wt1 = tendons_info.wrap_type[i_t, w + 1]
+                        is_geom_next = wt1 == gs.WRAP_TYPE.SPHERE or wt1 == gs.WRAP_TYPE.CYLINDER
+                    if is_geom_next:
+                        is_cyl = tendons_info.wrap_type[i_t, w + 1] == gs.WRAP_TYPE.CYLINDER
+                        sideid = tendons_info.wrap_sideid[i_t, w + 1]
+                        geom_body = tendons_info.wrap_geom_link[i_t, w + 1]
+                        site1_id = tendons_info.wrap_objid[i_t, w + 2]
+                        body1 = sites_info.link_idx[site1_id]
+                        next_pnt = func_site_world_pos(site1_id, i_b, sites_info, links_state)
+
+                        # Geom world pose from its owning link's transform (wrap geoms are frames on links).
+                        link_pos = links_state.pos[geom_body, i_b]
+                        link_quat = links_state.quat[geom_body, i_b]
+                        geom_pos = link_pos + gu.qd_transform_by_quat(tendons_info.wrap_geom_pos[i_t, w + 1], link_quat)
+                        geom_quat = gu.qd_transform_quat_by_quat(link_quat, tendons_info.wrap_geom_quat[i_t, w + 1])
+                        geom_R = gu.qd_quat_to_R(geom_quat, EPS)
+                        radius = tendons_info.wrap_geom_radius[i_t, w + 1]
+                        has_side = sideid >= 0
+                        side_pnt = qd.Vector.zero(gs.qd_float, 3)
+                        if has_side:
+                            side_pnt = func_site_world_pos(sideid, i_b, sites_info, links_state)
+                        wrapv = func_wrap(cur_pnt, next_pnt, geom_pos, geom_R, radius, is_cyl, has_side, side_pnt)
+                        wlen = wrapv[0]
+                        if wlen >= 0.0:
+                            w0 = qd.Vector([wrapv[1], wrapv[2], wrapv[3]])
+                            w1 = qd.Vector([wrapv[4], wrapv[5], wrapv[6]])
+                            # segment site -> first wrap point
+                            length = length + func_add_segment(
+                                i_t,
+                                i_b,
+                                prev_pnt,
+                                prev_body,
+                                w0,
+                                geom_body,
+                                gs.qd_float(1.0) / divisor,
+                                EPS,
+                                tendons_state,
+                                dofs_state,
+                                links_info,
+                                links_state,
+                                static_rigid_sim_config,
+                            )
+                            # wrapped arc (both endpoints on the geom body: length only, no moment)
+                            length = length + wlen / divisor
+                            prev_pnt = w1
+                            prev_body = geom_body
+                            if path_n < max_path:
+                                tendons_state.path_pos[i_t, path_n, i_b] = w0
+                                path_n = path_n + 1
+                            if path_n < max_path:
+                                tendons_state.path_pos[i_t, path_n, i_b] = w1
+                                path_n = path_n + 1
+                        # advance past the geom element; the next site (w+2) is handled on the next iteration
+                        w = w + 2
+                    else:
+                        w = w + 1
+                else:
+                    w = w + 1
+        tendons_state.length[i_t, i_b] = length
+        tendons_state.path_num[i_t, i_b] = path_n
+
+        # Tendon velocity = sum_i moment_i * qvel_i over the relevant DOFs.
+        velocity = gs.qd_float(0.0)
+        for k in range(n_mem):
+            i_d = tendons_info.dof_idx[i_t, k]
+            velocity = velocity + tendons_state.moment[i_t, i_d, i_b] * dofs_state.vel[i_d, i_b]
+        tendons_state.velocity[i_t, i_b] = velocity
 
 
 @qd.func
@@ -1095,6 +1625,8 @@ def func_torque_and_passive_force(
     links_info: array_class.LinksInfo,
     joints_info: array_class.JointsInfo,
     geoms_state: array_class.GeomsState,
+    tendons_info: array_class.TendonsInfo,
+    tendons_state: array_class.TendonsState,
     rigid_global_info: array_class.RigidGlobalInfo,
     static_rigid_sim_config: qd.template(),
     island_state: array_class.IslandState,
@@ -1277,6 +1809,53 @@ def func_torque_and_passive_force(
                                 -dofs_state.pos[dof_start + j_d, i_b] * dofs_info.stiffness[I_d],
                                 BW,
                             )
+
+    # Tendons: project passive (spring + damping) and actuator transmission forces onto the relevant DOFs via the
+    # per-step moment arm computed in func_compute_tendon_length_moment (moment == coef for fixed tendons; geometric
+    # for spatial ones). This runs after the per-DOF actuator/passive assignment above, so the `+=` accumulates on top.
+    # NOTE: tendon damping is applied explicitly here (into qf_passive). This is exact under the Euler integrator and a
+    # first-order approximation under implicitfast (MuJoCo folds tendon damping into the implicit velocity update via a
+    # dense moment_i*moment_j block on the mass matrix, which is not replicated here). Tendon stiffness, being a
+    # position-dependent force, is explicit in MuJoCo too, so it matches under both integrators.
+    _B_T = dofs_state.ctrl_mode.shape[1]
+    qd.loop_config(serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL)
+    for i_t, i_b in qd.ndrange(qd.static(static_rigid_sim_config.n_tendons), _B_T):
+        n_mem = tendons_info.n_members[i_t]
+        length = tendons_state.length[i_t, i_b]
+        velocity = tendons_state.velocity[i_t, i_b]
+
+        # Passive spring with [lo, hi] deadband + linear damping.
+        springlength = tendons_info.springlength[i_t]
+        stiffness = tendons_info.stiffness[i_t]
+        spring_force = gs.qd_float(0.0)
+        if length < springlength[0]:
+            spring_force = -stiffness * (length - springlength[0])
+        elif length > springlength[1]:
+            spring_force = -stiffness * (length - springlength[1])
+        passive_force = spring_force - tendons_info.damping[i_t] * velocity
+
+        # Actuator transmission (affine model, mirroring the per-DOF actuator formula above).
+        act_force = gs.qd_float(0.0)
+        ctrl_mode = tendons_state.ctrl_mode[i_t, i_b]
+        if ctrl_mode == gs.CTRL_MODE.FORCE:
+            act_force = tendons_state.ctrl_force[i_t, i_b]
+        elif ctrl_mode == gs.CTRL_MODE.VELOCITY:
+            act_force = -tendons_info.act_bias[i_t][2] * (tendons_state.ctrl_vel[i_t, i_b] - velocity)
+        elif ctrl_mode == gs.CTRL_MODE.POSITION:
+            act_force = (
+                tendons_info.act_gain[i_t] * (tendons_state.ctrl_pos[i_t, i_b] - length)
+                + tendons_info.act_bias[i_t][0]
+                + (tendons_info.act_gain[i_t] + tendons_info.act_bias[i_t][1]) * length
+                + tendons_info.act_bias[i_t][2] * (velocity - tendons_state.ctrl_vel[i_t, i_b])
+            )
+        act_force = qd.math.clamp(act_force, tendons_info.force_range[i_t][0], tendons_info.force_range[i_t][1])
+
+        # Project scalar forces onto the relevant DOFs via the moment arm.
+        for k in range(n_mem):
+            i_d = tendons_info.dof_idx[i_t, k]
+            moment = tendons_state.moment[i_t, i_d, i_b]
+            func_add_safe_backward(dofs_state.qf_passive, [i_d, i_b], moment * passive_force, BW)
+            func_add_safe_backward(dofs_state.qf_applied, [i_d, i_b], moment * act_force, BW)
 
 
 @qd.func
@@ -1710,6 +2289,10 @@ def kernel_forward_dynamics_without_qacc(
     entities_state: array_class.EntitiesState,
     entities_info: array_class.EntitiesInfo,
     geoms_state: array_class.GeomsState,
+    geoms_info: array_class.GeomsInfo,
+    sites_info: array_class.SitesInfo,
+    tendons_info: array_class.TendonsInfo,
+    tendons_state: array_class.TendonsState,
     rigid_global_info: array_class.RigidGlobalInfo,
     static_rigid_sim_config: qd.template(),
     island_state: array_class.IslandState,
@@ -1735,6 +2318,18 @@ def kernel_forward_dynamics_without_qacc(
         static_rigid_sim_config=static_rigid_sim_config,
         is_backward=is_backward,
     )
+    func_compute_tendon_length_moment(
+        tendons_info=tendons_info,
+        tendons_state=tendons_state,
+        sites_info=sites_info,
+        dofs_state=dofs_state,
+        links_info=links_info,
+        links_state=links_state,
+        geoms_state=geoms_state,
+        geoms_info=geoms_info,
+        rigid_global_info=rigid_global_info,
+        static_rigid_sim_config=static_rigid_sim_config,
+    )
     func_torque_and_passive_force(
         entities_state=entities_state,
         entities_info=entities_info,
@@ -1744,6 +2339,8 @@ def kernel_forward_dynamics_without_qacc(
         links_info=links_info,
         joints_info=joints_info,
         geoms_state=geoms_state,
+        tendons_info=tendons_info,
+        tendons_state=tendons_state,
         rigid_global_info=rigid_global_info,
         static_rigid_sim_config=static_rigid_sim_config,
         island_state=island_state,

--- a/genesis/engine/solvers/rigid/abd/misc.py
+++ b/genesis/engine/solvers/rigid/abd/misc.py
@@ -755,6 +755,99 @@ def kernel_init_equality_fields(
             equalities_info.sol_params[i_eq, i_b][j] = equalities_sol_params[i_eq, j]
 
 
+@qd.kernel(fastcache=True)
+def kernel_init_site_fields(
+    sites_link_idx: qd.types.ndarray(),
+    sites_pos: qd.types.ndarray(),
+    sites_quat: qd.types.ndarray(),
+    # Quadrants variables
+    sites_info: array_class.SitesInfo,
+    static_rigid_sim_config: qd.template(),
+):
+    n_sites = sites_link_idx.shape[0]
+    qd.loop_config(serialize=qd.static(static_rigid_sim_config.para_level < gs.PARA_LEVEL.PARTIAL))
+    for i_s in range(n_sites):
+        sites_info.link_idx[i_s] = sites_link_idx[i_s]
+        for j in qd.static(range(3)):
+            sites_info.pos[i_s][j] = sites_pos[i_s, j]
+        for j in qd.static(range(4)):
+            sites_info.quat[i_s][j] = sites_quat[i_s, j]
+
+
+@qd.kernel(fastcache=True)
+def kernel_init_tendon_fields(
+    tendons_kind: qd.types.ndarray(),
+    tendons_n_members: qd.types.ndarray(),
+    tendons_dof_idx: qd.types.ndarray(),
+    tendons_q_idx: qd.types.ndarray(),
+    tendons_coef: qd.types.ndarray(),
+    tendons_n_wraps: qd.types.ndarray(),
+    tendons_wrap_type: qd.types.ndarray(),
+    tendons_wrap_objid: qd.types.ndarray(),
+    tendons_wrap_prm: qd.types.ndarray(),
+    tendons_wrap_sideid: qd.types.ndarray(),
+    tendons_wrap_geom_link: qd.types.ndarray(),
+    tendons_wrap_geom_pos: qd.types.ndarray(),
+    tendons_wrap_geom_quat: qd.types.ndarray(),
+    tendons_wrap_geom_radius: qd.types.ndarray(),
+    tendons_stiffness: qd.types.ndarray(),
+    tendons_damping: qd.types.ndarray(),
+    tendons_springlength: qd.types.ndarray(),
+    tendons_frictionloss: qd.types.ndarray(),
+    tendons_limited: qd.types.ndarray(),
+    tendons_limit: qd.types.ndarray(),
+    tendons_sol_params: qd.types.ndarray(),
+    tendons_sol_params_limit: qd.types.ndarray(),
+    tendons_act_gain: qd.types.ndarray(),
+    tendons_act_bias: qd.types.ndarray(),
+    tendons_force_range: qd.types.ndarray(),
+    tendons_length0: qd.types.ndarray(),
+    # Quadrants variables
+    tendons_info: array_class.TendonsInfo,
+    static_rigid_sim_config: qd.template(),
+):
+    n_tendons = tendons_n_members.shape[0]
+    max_members = tendons_dof_idx.shape[1]
+    max_wraps = tendons_wrap_type.shape[1]
+
+    # TendonsInfo is not batched (tendon parameters do not vary per environment).
+    qd.loop_config(serialize=qd.static(static_rigid_sim_config.para_level < gs.PARA_LEVEL.PARTIAL))
+    for i_t in range(n_tendons):
+        tendons_info.kind[i_t] = tendons_kind[i_t]
+        tendons_info.n_members[i_t] = tendons_n_members[i_t]
+        tendons_info.n_wraps[i_t] = tendons_n_wraps[i_t]
+        tendons_info.stiffness[i_t] = tendons_stiffness[i_t]
+        tendons_info.damping[i_t] = tendons_damping[i_t]
+        tendons_info.frictionloss[i_t] = tendons_frictionloss[i_t]
+        tendons_info.limited[i_t] = tendons_limited[i_t]
+        tendons_info.act_gain[i_t] = tendons_act_gain[i_t]
+        tendons_info.length0[i_t] = tendons_length0[i_t]
+        for k in range(max_members):
+            tendons_info.dof_idx[i_t, k] = tendons_dof_idx[i_t, k]
+            tendons_info.q_idx[i_t, k] = tendons_q_idx[i_t, k]
+            tendons_info.coef[i_t, k] = tendons_coef[i_t, k]
+        for w in range(max_wraps):
+            tendons_info.wrap_type[i_t, w] = tendons_wrap_type[i_t, w]
+            tendons_info.wrap_objid[i_t, w] = tendons_wrap_objid[i_t, w]
+            tendons_info.wrap_prm[i_t, w] = tendons_wrap_prm[i_t, w]
+            tendons_info.wrap_sideid[i_t, w] = tendons_wrap_sideid[i_t, w]
+            tendons_info.wrap_geom_link[i_t, w] = tendons_wrap_geom_link[i_t, w]
+            tendons_info.wrap_geom_radius[i_t, w] = tendons_wrap_geom_radius[i_t, w]
+            for j in qd.static(range(3)):
+                tendons_info.wrap_geom_pos[i_t, w][j] = tendons_wrap_geom_pos[i_t, w, j]
+            for j in qd.static(range(4)):
+                tendons_info.wrap_geom_quat[i_t, w][j] = tendons_wrap_geom_quat[i_t, w, j]
+        for j in qd.static(range(2)):
+            tendons_info.springlength[i_t][j] = tendons_springlength[i_t, j]
+            tendons_info.limit[i_t][j] = tendons_limit[i_t, j]
+            tendons_info.force_range[i_t][j] = tendons_force_range[i_t, j]
+        for j in qd.static(range(3)):
+            tendons_info.act_bias[i_t][j] = tendons_act_bias[i_t, j]
+        for j in qd.static(range(7)):
+            tendons_info.sol_params[i_t][j] = tendons_sol_params[i_t, j]
+            tendons_info.sol_params_limit[i_t][j] = tendons_sol_params_limit[i_t, j]
+
+
 # --------------------------------------------------------------------------------------
 # External force kernels
 # --------------------------------------------------------------------------------------

--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -117,6 +117,8 @@ class ConstraintSolver:
             + sum(joint.type in (gs.JOINT_TYPE.REVOLUTE, gs.JOINT_TYPE.PRISMATIC) for joint in self._solver.joints)
             + self._solver.n_dofs
             + self._solver.n_candidate_equalities_ * 6
+            # One limit row + one frictionloss row per fixed tendon.
+            + self._solver.n_tendons * 2
         )
         self.len_constraints_ = max(1, self.len_constraints)
 
@@ -277,6 +279,8 @@ class ConstraintSolver:
             self._solver.dofs_info,
             self._solver.joints_info,
             self._solver.equalities_info,
+            self._solver.tendons_info,
+            self._solver.tendons_state,
             self.constraint_state,
             self._collider._collider_state,
             self._solver._rigid_global_info,
@@ -291,6 +295,8 @@ class ConstraintSolver:
             self._solver.dofs_info,
             self._solver.joints_info,
             self._solver.equalities_info,
+            self._solver.tendons_info,
+            self._solver.tendons_state,
             self.constraint_state,
             self._collider._collider_state,
             self.island_state,
@@ -1163,6 +1169,82 @@ def func_equality_joint(
     _sort_relevant_dofs_descending(constraint_state, n_con, con_n_dofs, i_b, static_rigid_sim_config)
 
 
+@qd.func
+def func_equality_tendon(
+    i_b,
+    i_e,
+    tendons_info: array_class.TendonsInfo,
+    tendons_state: array_class.TendonsState,
+    dofs_info: array_class.DofsInfo,
+    equalities_info: array_class.EqualitiesInfo,
+    constraint_state: array_class.ConstraintState,
+    rigid_global_info: array_class.RigidGlobalInfo,
+    static_rigid_sim_config: qd.template(),
+):
+    # Quartic coupling of two tendon lengths (relative to their reference lengths), mirroring func_equality_joint but
+    # with the per-step tendon moment rows as the Jacobian:  length1 - length1_0 = sum_k a_k * (length2 - length2_0)^k.
+    EPS = rigid_global_info.EPS[None]
+    n_dofs = constraint_state.jac.shape[1]
+    sol_params = equalities_info.sol_params[i_e, i_b]
+    i_t1 = equalities_info.eq_obj1id[i_e, i_b]
+    i_t2 = equalities_info.eq_obj2id[i_e, i_b]
+
+    n_con = qd.atomic_add(constraint_state.n_constraints[i_b], 1)
+    qd.atomic_add(constraint_state.n_constraints_equality[i_b], 1)
+
+    if qd.static(static_rigid_sim_config.sparse_solve):
+        for i_d_ in range(constraint_state.jac_n_dofs[n_con, i_b]):
+            i_d = constraint_state.jac_dofs_idx[n_con, i_d_, i_b]
+            constraint_state.jac[n_con, i_d, i_b] = gs.qd_float(0.0)
+    else:
+        for i_d in range(n_dofs):
+            constraint_state.jac[n_con, i_d, i_b] = gs.qd_float(0.0)
+
+    pos = tendons_state.length[i_t1, i_b] - tendons_info.length0[i_t1]
+    diff = tendons_state.length[i_t2, i_b] - tendons_info.length0[i_t2]
+    deriv = gs.qd_float(0.0)
+    for i_5 in range(5):
+        diff_power = diff**i_5
+        pos = pos - diff_power * equalities_info.eq_data[i_e, i_b][i_5]
+        if i_5 < 4:
+            deriv = deriv + equalities_info.eq_data[i_e, i_b][i_5 + 1] * diff_power * (i_5 + 1)
+
+    # Assemble the Jacobian row = moment(t1) - deriv * moment(t2) over the union of the two tendons' relevant DOFs.
+    con_n_dofs = 0
+    invweight = gs.qd_float(0.0)
+    for k in range(tendons_info.n_members[i_t1]):
+        i_d = tendons_info.dof_idx[i_t1, k]
+        constraint_state.jac[n_con, i_d, i_b] = tendons_state.moment[i_t1, i_d, i_b]
+        constraint_state.jac_dofs_idx[n_con, con_n_dofs, i_b] = i_d
+        con_n_dofs += 1
+        I_d = [i_d, i_b] if qd.static(static_rigid_sim_config.batch_dofs_info) else i_d
+        invweight = invweight + dofs_info.invweight[I_d]
+    for k in range(tendons_info.n_members[i_t2]):
+        i_d = tendons_info.dof_idx[i_t2, k]
+        add_val = -deriv * tendons_state.moment[i_t2, i_d, i_b]
+        found = False
+        for kk in range(con_n_dofs):
+            if constraint_state.jac_dofs_idx[n_con, kk, i_b] == i_d:
+                found = True
+        if found:
+            constraint_state.jac[n_con, i_d, i_b] = constraint_state.jac[n_con, i_d, i_b] + add_val
+        else:
+            constraint_state.jac[n_con, i_d, i_b] = add_val
+            constraint_state.jac_dofs_idx[n_con, con_n_dofs, i_b] = i_d
+            con_n_dofs += 1
+            I_d = [i_d, i_b] if qd.static(static_rigid_sim_config.batch_dofs_info) else i_d
+            invweight = invweight + dofs_info.invweight[I_d]
+    constraint_state.jac_n_dofs[n_con, i_b] = con_n_dofs
+
+    jac_qvel = tendons_state.velocity[i_t1, i_b] - deriv * tendons_state.velocity[i_t2, i_b]
+    imp, aref = gu.imp_aref(sol_params, -qd.abs(pos), jac_qvel, pos)
+    diag = qd.max(invweight * (1.0 - imp) / imp, EPS)
+    constraint_state.diag[n_con, i_b] = diag
+    constraint_state.aref[n_con, i_b] = aref
+    constraint_state.efc_D[n_con, i_b] = 1.0 / diag
+    _sort_relevant_dofs_descending(constraint_state, n_con, con_n_dofs, i_b, static_rigid_sim_config)
+
+
 @qd.kernel(fastcache=True)
 def add_equality_constraints(
     links_info: array_class.LinksInfo,
@@ -1171,6 +1253,8 @@ def add_equality_constraints(
     dofs_info: array_class.DofsInfo,
     joints_info: array_class.JointsInfo,
     equalities_info: array_class.EqualitiesInfo,
+    tendons_info: array_class.TendonsInfo,
+    tendons_state: array_class.TendonsState,
     constraint_state: array_class.ConstraintState,
     collider_state: array_class.ColliderState,
     rigid_global_info: array_class.RigidGlobalInfo,
@@ -1215,6 +1299,18 @@ def add_equality_constraints(
                     i_e,
                     joints_info=joints_info,
                     dofs_state=dofs_state,
+                    dofs_info=dofs_info,
+                    equalities_info=equalities_info,
+                    constraint_state=constraint_state,
+                    rigid_global_info=rigid_global_info,
+                    static_rigid_sim_config=static_rigid_sim_config,
+                )
+            elif equalities_info.eq_type[i_e, i_b] == gs.EQUALITY_TYPE.TENDON:
+                func_equality_tendon(
+                    i_b,
+                    i_e,
+                    tendons_info=tendons_info,
+                    tendons_state=tendons_state,
                     dofs_info=dofs_info,
                     equalities_info=equalities_info,
                     constraint_state=constraint_state,
@@ -1342,6 +1438,8 @@ def add_inequality_constraints(
     dofs_info: array_class.DofsInfo,
     joints_info: array_class.JointsInfo,
     equalities_info: array_class.EqualitiesInfo,
+    tendons_info: array_class.TendonsInfo,
+    tendons_state: array_class.TendonsState,
     constraint_state: array_class.ConstraintState,
     collider_state: array_class.ColliderState,
     island_state: array_class.IslandState,
@@ -1390,6 +1488,8 @@ def add_inequality_constraints(
         joints_info=joints_info,
         dofs_info=dofs_info,
         dofs_state=dofs_state,
+        tendons_info=tendons_info,
+        tendons_state=tendons_state,
         rigid_global_info=rigid_global_info,
         constraint_state=constraint_state,
         static_rigid_sim_config=static_rigid_sim_config,
@@ -1414,6 +1514,15 @@ def add_inequality_constraints(
             constraint_state=constraint_state,
             static_rigid_sim_config=static_rigid_sim_config,
         )
+    add_tendon_limit_constraints(
+        dofs_info=dofs_info,
+        dofs_state=dofs_state,
+        tendons_info=tendons_info,
+        tendons_state=tendons_state,
+        rigid_global_info=rigid_global_info,
+        constraint_state=constraint_state,
+        static_rigid_sim_config=static_rigid_sim_config,
+    )
 
 
 @qd.func
@@ -1683,6 +1792,8 @@ def add_frictionloss_constraints(
     joints_info: array_class.JointsInfo,
     dofs_info: array_class.DofsInfo,
     dofs_state: array_class.DofsState,
+    tendons_info: array_class.TendonsInfo,
+    tendons_state: array_class.TendonsState,
     rigid_global_info: array_class.RigidGlobalInfo,
     constraint_state: array_class.ConstraintState,
     static_rigid_sim_config: qd.template(),
@@ -1733,6 +1844,102 @@ def add_frictionloss_constraints(
 
                         constraint_state.jac_dofs_idx[i_con, 0, i_b] = i_d
                         constraint_state.jac_n_dofs[i_con, i_b] = 1
+
+        # Fixed-tendon frictionloss rows (multi-DOF Jacobian = coef). Kept in the same contiguous frictionloss block as
+        # the per-DOF rows above so `n_constraints_equality + n_constraints_frictionloss` still bounds the block.
+        for i_t in range(qd.static(static_rigid_sim_config.n_tendons)):
+            if tendons_info.frictionloss[i_t] > EPS:
+                n_mem = tendons_info.n_members[i_t]
+                jac_qvel = tendons_state.velocity[i_t, i_b]
+                invweight = gs.qd_float(0.0)
+                for k in range(n_mem):
+                    i_d = tendons_info.dof_idx[i_t, k]
+                    I_d = [i_d, i_b] if qd.static(static_rigid_sim_config.batch_dofs_info) else i_d
+                    invweight = invweight + dofs_info.invweight[I_d]
+                imp, aref = gu.imp_aref(tendons_info.sol_params[i_t], 0.0, jac_qvel, 0.0)
+                diag = qd.max(invweight * (1.0 - imp) / imp, EPS)
+
+                i_con = qd.atomic_add(constraint_state.n_constraints[i_b], 1)
+                qd.atomic_add(constraint_state.n_constraints_frictionloss[i_b], 1)
+
+                constraint_state.diag[i_con, i_b] = diag
+                constraint_state.aref[i_con, i_b] = aref
+                constraint_state.efc_D[i_con, i_b] = 1.0 / diag
+                constraint_state.efc_frictionloss[i_con, i_b] = tendons_info.frictionloss[i_t]
+                for i_d2 in range(n_dofs):
+                    constraint_state.jac[i_con, i_d2, i_b] = gs.qd_float(0.0)
+                con_n_dofs = 0
+                for k in range(n_mem):
+                    i_d = tendons_info.dof_idx[i_t, k]
+                    constraint_state.jac[i_con, i_d, i_b] = tendons_state.moment[i_t, i_d, i_b]
+                    constraint_state.jac_dofs_idx[i_con, con_n_dofs, i_b] = i_d
+                    con_n_dofs += 1
+                constraint_state.jac_n_dofs[i_con, i_b] = con_n_dofs
+                _sort_relevant_dofs_descending(constraint_state, i_con, con_n_dofs, i_b, static_rigid_sim_config)
+
+
+@qd.func
+def add_tendon_limit_constraints(
+    dofs_info: array_class.DofsInfo,
+    dofs_state: array_class.DofsState,
+    tendons_info: array_class.TendonsInfo,
+    tendons_state: array_class.TendonsState,
+    rigid_global_info: array_class.RigidGlobalInfo,
+    constraint_state: array_class.ConstraintState,
+    static_rigid_sim_config: qd.template(),
+):
+    EPS = rigid_global_info.EPS[None]
+
+    _B = constraint_state.jac.shape[2]
+    n_dofs = dofs_state.ctrl_mode.shape[0]
+
+    qd.loop_config(
+        name="add_tendon_limit_constraints",
+        serialize=qd.static(static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL),
+    )
+    for i_b in range(_B):
+        for i_t in range(qd.static(static_rigid_sim_config.n_tendons)):
+            if tendons_info.limited[i_t]:
+                length = tendons_state.length[i_t, i_b]
+                pos_delta_min = length - tendons_info.limit[i_t][0]
+                pos_delta_max = tendons_info.limit[i_t][1] - length
+                pos_delta = qd.min(pos_delta_min, pos_delta_max)
+
+                if pos_delta < 0:
+                    sign = (pos_delta_min < pos_delta_max) * 2 - 1
+                    jac_qvel = sign * tendons_state.velocity[i_t, i_b]
+
+                    n_mem = tendons_info.n_members[i_t]
+                    invweight = gs.qd_float(0.0)
+                    for k in range(n_mem):
+                        i_d = tendons_info.dof_idx[i_t, k]
+                        I_d = [i_d, i_b] if qd.static(static_rigid_sim_config.batch_dofs_info) else i_d
+                        invweight = invweight + dofs_info.invweight[I_d]
+
+                    imp, aref = gu.imp_aref(tendons_info.sol_params_limit[i_t], pos_delta, jac_qvel, pos_delta)
+                    diag = qd.max(invweight * (1.0 - imp) / imp, EPS)
+
+                    n_con = qd.atomic_add(constraint_state.n_constraints[i_b], 1)
+                    constraint_state.diag[n_con, i_b] = diag
+                    constraint_state.aref[n_con, i_b] = aref
+                    constraint_state.efc_D[n_con, i_b] = 1.0 / diag
+
+                    if qd.static(static_rigid_sim_config.sparse_solve):
+                        for i_d2_ in range(constraint_state.jac_n_dofs[n_con, i_b]):
+                            i_d2 = constraint_state.jac_dofs_idx[n_con, i_d2_, i_b]
+                            constraint_state.jac[n_con, i_d2, i_b] = gs.qd_float(0.0)
+                    else:
+                        for i_d2 in range(n_dofs):
+                            constraint_state.jac[n_con, i_d2, i_b] = gs.qd_float(0.0)
+
+                    con_n_dofs = 0
+                    for k in range(n_mem):
+                        i_d = tendons_info.dof_idx[i_t, k]
+                        constraint_state.jac[n_con, i_d, i_b] = sign * tendons_state.moment[i_t, i_d, i_b]
+                        constraint_state.jac_dofs_idx[n_con, con_n_dofs, i_b] = i_d
+                        con_n_dofs += 1
+                    constraint_state.jac_n_dofs[n_con, i_b] = con_n_dofs
+                    _sort_relevant_dofs_descending(constraint_state, n_con, con_n_dofs, i_b, static_rigid_sim_config)
 
 
 # ====================================== Runtime User-Specified Weld Constraints ======================================

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -57,6 +57,8 @@ from .abd.misc import (
     kernel_init_vgeom_fields,
     kernel_init_entity_fields,
     kernel_init_equality_fields,
+    kernel_init_site_fields,
+    kernel_init_tendon_fields,
     kernel_apply_links_external_force,
     kernel_apply_links_external_torque,
     kernel_update_geoms_render_T,
@@ -153,6 +155,10 @@ from .abd.accessor import (
     kernel_control_dofs_velocity,
     kernel_control_dofs_position,
     kernel_control_dofs_position_velocity,
+    kernel_control_tendons_force,
+    kernel_control_tendons_velocity,
+    kernel_control_tendons_position,
+    kernel_get_tendons_length,
     kernel_get_links_vel,
     kernel_get_links_acc,
     kernel_get_dofs_control_force,
@@ -341,9 +347,13 @@ class RigidSolver(KinematicSolver):
         self._n_faces = self.n_faces
         self._n_edges = self.n_edges
         self._n_equalities = self.n_equalities
+        self._n_tendons = self.n_tendons
+        self._n_sites = self.n_sites
 
         self._geoms = self.geoms
         self._equalities = self.equalities
+        self._tendons = self.tendons
+        self._sites = self.sites
 
         self.n_geoms_ = max(1, self.n_geoms)
         self.n_cells_ = max(1, self.n_cells)
@@ -353,6 +363,20 @@ class RigidSolver(KinematicSolver):
         self.n_free_verts_ = max(1, self.n_free_verts)
         self.n_fixed_verts_ = max(1, self.n_fixed_verts)
         self.n_candidate_equalities_ = max(1, self.n_equalities + self._options.max_dynamic_constraints)
+        self.n_tendons_ = self.n_tendons
+        self.n_sites_ = self.n_sites
+        # A fixed tendon's "members" are its coupled joints; a spatial tendon's relevant DOFs (union of path-body parent
+        # chains, resolved in _init_tendon_fields) are bounded by n_dofs. Over-allocate to that bound so the member
+        # arrays fit both kinds.
+        _has_spatial = any(tendon.kind == gs.TENDON_TYPE.SPATIAL for tendon in self.tendons)
+        _max_fixed_members = max(
+            (len(tendon.members) for tendon in self.tendons if tendon.kind == gs.TENDON_TYPE.FIXED), default=0
+        )
+        self.tendon_max_members_ = max(_max_fixed_members, self.n_dofs if _has_spatial else 0)
+        self.tendon_max_wraps_ = max((len(tendon.wraps) for tendon in self.tendons), default=0)
+        # Upper bound on a spatial tendon's world path points: each wrap element yields <= 2 points (a wrap geom adds
+        # its two tangent points; a site adds one). Used to size the debug-visualization path buffer.
+        self.tendon_max_path_points_ = 2 * self.tendon_max_wraps_
 
         # Resolve precision-dependent tolerance default
         if self._options.tolerance is None:
@@ -365,6 +389,8 @@ class RigidSolver(KinematicSolver):
         self._init_vert_fields()
         self._init_geom_fields()
         self._init_equality_fields()
+        self._init_site_fields()
+        self._init_tendon_fields()
         self._init_dof_length()
 
         self._init_invweight_and_meaninertia(force_update=False)
@@ -513,6 +539,7 @@ class RigidSolver(KinematicSolver):
             enable_multi_contact=self._enable_multi_contact,
             enable_collision=self._enable_collision,
             enable_joint_limit=self._enable_joint_limit,
+            n_tendons=self.n_tendons,
             box_box_detection=self._box_box_detection,
             use_contact_island=self._use_contact_island,
             # The per-island solve engages wherever islands are on by default (CPU, where it composes with the sparse
@@ -1138,6 +1165,166 @@ class RigidSolver(KinematicSolver):
                 static_rigid_sim_config=self._static_rigid_sim_config,
             )
 
+    def _init_site_fields(self):
+        self.sites_info = self.data_manager.sites_info
+        if self.n_sites > 0:
+            sites = self.sites
+            site_link = np.zeros((self.n_sites,), dtype=gs.np_int)
+            site_pos = np.zeros((self.n_sites, 3), dtype=gs.np_float)
+            site_quat = np.zeros((self.n_sites, 4), dtype=gs.np_float)
+            for i_s, site in enumerate(sites):
+                site_link[i_s] = site.entity.get_link(site.link_name).idx
+                site_pos[i_s] = site.pos
+                site_quat[i_s] = site.quat
+            kernel_init_site_fields(
+                sites_link_idx=site_link,
+                sites_pos=site_pos,
+                sites_quat=site_quat,
+                # Quadrants variables
+                sites_info=self.sites_info,
+                static_rigid_sim_config=self._static_rigid_sim_config,
+            )
+
+    def _chain_dofs(self, link):
+        """Global DOF indices on the kinematic path from `link` up to (and including) the root."""
+        dofs = []
+        links_by_idx = {lnk.idx: lnk for lnk in self.links}
+        cur = link
+        while cur is not None:
+            dofs.extend(range(cur.dof_start, cur.dof_end))
+            parent_idx = cur.parent_idx
+            cur = links_by_idx.get(parent_idx) if parent_idx >= 0 else None
+        return dofs
+
+    def _init_tendon_fields(self):
+        self.tendons_info = self.data_manager.tendons_info
+        self.tendons_state = self.data_manager.tendons_state
+        if self.n_tendons == 0:
+            return
+
+        tendons = self.tendons
+        max_members = max(self.tendon_max_members_, 1)
+        max_wraps = max(self.tendon_max_wraps_, 1)
+
+        kind = np.zeros((self.n_tendons,), dtype=gs.np_int)
+        n_members = np.zeros((self.n_tendons,), dtype=gs.np_int)
+        dof_idx = np.zeros((self.n_tendons, max_members), dtype=gs.np_int)
+        q_idx = np.zeros((self.n_tendons, max_members), dtype=gs.np_int)
+        coef = np.zeros((self.n_tendons, max_members), dtype=gs.np_float)
+        n_wraps = np.zeros((self.n_tendons,), dtype=gs.np_int)
+        wrap_type = np.zeros((self.n_tendons, max_wraps), dtype=gs.np_int)
+        wrap_objid = np.full((self.n_tendons, max_wraps), -1, dtype=gs.np_int)
+        wrap_prm = np.zeros((self.n_tendons, max_wraps), dtype=gs.np_float)
+        wrap_sideid = np.full((self.n_tendons, max_wraps), -1, dtype=gs.np_int)
+        wrap_geom_link = np.full((self.n_tendons, max_wraps), -1, dtype=gs.np_int)
+        wrap_geom_pos = np.zeros((self.n_tendons, max_wraps, 3), dtype=gs.np_float)
+        wrap_geom_quat = np.tile(np.array([1.0, 0.0, 0.0, 0.0], dtype=gs.np_float), (self.n_tendons, max_wraps, 1))
+        wrap_geom_radius = np.zeros((self.n_tendons, max_wraps), dtype=gs.np_float)
+        stiffness = np.zeros((self.n_tendons,), dtype=gs.np_float)
+        damping = np.zeros((self.n_tendons,), dtype=gs.np_float)
+        springlength = np.zeros((self.n_tendons, 2), dtype=gs.np_float)
+        frictionloss = np.zeros((self.n_tendons,), dtype=gs.np_float)
+        limited = np.zeros((self.n_tendons,), dtype=gs.np_int)
+        limit = np.zeros((self.n_tendons, 2), dtype=gs.np_float)
+        act_gain = np.zeros((self.n_tendons,), dtype=gs.np_float)
+        act_bias = np.zeros((self.n_tendons, 3), dtype=gs.np_float)
+        force_range = np.tile([-np.inf, np.inf], (self.n_tendons, 1)).astype(gs.np_float)
+        sol_params = np.zeros((self.n_tendons, 7), dtype=gs.np_float)
+        sol_params_limit = np.zeros((self.n_tendons, 7), dtype=gs.np_float)
+        length0 = np.zeros((self.n_tendons,), dtype=gs.np_float)
+
+        for i_t, tendon in enumerate(tendons):
+            entity = tendon.entity
+            kind[i_t] = int(tendon.kind)
+
+            if tendon.kind == gs.TENDON_TYPE.FIXED:
+                n_members[i_t] = len(tendon.members)
+                for k, (joint_name, c) in enumerate(tendon.members):
+                    joint = entity.get_joint(joint_name)
+                    if joint.n_dofs != 1:
+                        gs.raise_exception(
+                            f"(MJCF) Fixed tendon `{tendon.name}` references joint `{joint_name}` with "
+                            f"{joint.n_dofs} DOFs; only single-DOF joints are supported in fixed tendons."
+                        )
+                    dof_idx[i_t, k] = joint.dof_start
+                    q_idx[i_t, k] = joint.q_start
+                    coef[i_t, k] = c
+            else:
+                # Resolve the spatial wrap path (site/geom bodies -> global link idx, sites -> global site idx) and
+                # collect the relevant DOFs = union of the parent chains of every body appearing on the path.
+                relevant = set()
+                for w, wrap in enumerate(tendon.wraps):
+                    wt = wrap["type"]
+                    wrap_type[i_t, w] = int(wt)
+                    if wt == gs.WRAP_TYPE.SITE:
+                        site = entity.get_site(wrap["site_name"])
+                        wrap_objid[i_t, w] = site.idx
+                        relevant.update(self._chain_dofs(entity.get_link(site.link_name)))
+                    elif wt == gs.WRAP_TYPE.PULLEY:
+                        wrap_prm[i_t, w] = wrap["divisor"]
+                    else:  # SPHERE / CYLINDER
+                        geom_link = entity.get_link(wrap["geom_body_name"])
+                        wrap_geom_link[i_t, w] = geom_link.idx
+                        wrap_geom_pos[i_t, w] = wrap["geom_pos"]
+                        wrap_geom_quat[i_t, w] = wrap["geom_quat"]
+                        wrap_geom_radius[i_t, w] = wrap["geom_radius"]
+                        relevant.update(self._chain_dofs(geom_link))
+                        if wrap["side_name"] is not None:
+                            wrap_sideid[i_t, w] = entity.get_site(wrap["side_name"]).idx
+                n_wraps[i_t] = len(tendon.wraps)
+                relevant = sorted(relevant)
+                n_members[i_t] = len(relevant)
+                for k, i_d in enumerate(relevant):
+                    dof_idx[i_t, k] = i_d
+
+            stiffness[i_t] = tendon._stiffness
+            damping[i_t] = tendon._damping
+            springlength[i_t] = tendon._springlength
+            frictionloss[i_t] = tendon._frictionloss
+            limited[i_t] = int(tendon._limited)
+            limit[i_t] = tendon._limit
+            act_gain[i_t] = tendon._act_gain
+            act_bias[i_t] = tendon._act_bias
+            force_range[i_t] = tendon._force_range
+            sol_params[i_t] = tendon._sol_params
+            sol_params_limit[i_t] = tendon._sol_params_limit
+            length0[i_t] = tendon._length0
+
+        _sanitize_sol_params(sol_params, self._sol_min_timeconst, self._sol_default_timeconst)
+        _sanitize_sol_params(sol_params_limit, self._sol_min_timeconst, self._sol_default_timeconst)
+
+        kernel_init_tendon_fields(
+            tendons_kind=kind,
+            tendons_n_members=n_members,
+            tendons_dof_idx=dof_idx,
+            tendons_q_idx=q_idx,
+            tendons_coef=coef,
+            tendons_n_wraps=n_wraps,
+            tendons_wrap_type=wrap_type,
+            tendons_wrap_objid=wrap_objid,
+            tendons_wrap_prm=wrap_prm,
+            tendons_wrap_sideid=wrap_sideid,
+            tendons_wrap_geom_link=wrap_geom_link,
+            tendons_wrap_geom_pos=wrap_geom_pos,
+            tendons_wrap_geom_quat=wrap_geom_quat,
+            tendons_wrap_geom_radius=wrap_geom_radius,
+            tendons_stiffness=stiffness,
+            tendons_damping=damping,
+            tendons_springlength=springlength,
+            tendons_frictionloss=frictionloss,
+            tendons_limited=limited,
+            tendons_limit=limit,
+            tendons_sol_params=sol_params,
+            tendons_sol_params_limit=sol_params_limit,
+            tendons_act_gain=act_gain,
+            tendons_act_bias=act_bias,
+            tendons_force_range=force_range,
+            tendons_length0=length0,
+            # Quadrants variables
+            tendons_info=self.tendons_info,
+            static_rigid_sim_config=self._static_rigid_sim_config,
+        )
+
     def _init_collider(self):
         self.collider = Collider(self)
 
@@ -1197,6 +1384,9 @@ class RigidSolver(KinematicSolver):
             self.geoms_info,
             self.entities_state,
             self.entities_info,
+            self.sites_info,
+            self.tendons_info,
+            self.tendons_state,
             self._rigid_global_info,
             self._static_rigid_sim_config,
             self.constraint_solver.island_state,
@@ -1330,6 +1520,10 @@ class RigidSolver(KinematicSolver):
             self.entities_state,
             self.entities_info,
             self.geoms_state,
+            self.geoms_info,
+            self.sites_info,
+            self.tendons_info,
+            self.tendons_state,
             self._rigid_global_info,
             self._static_rigid_sim_config,
             self.constraint_solver.island_state,
@@ -1661,6 +1855,10 @@ class RigidSolver(KinematicSolver):
             entities_state=self.entities_state,
             entities_info=self.entities_info,
             geoms_state=self.geoms_state,
+            geoms_info=self.geoms_info,
+            sites_info=self.sites_info,
+            tendons_info=self.tendons_info,
+            tendons_state=self.tendons_state,
             rigid_global_info=self._rigid_global_info,
             static_rigid_sim_config=self._static_rigid_sim_config,
             island_state=self.constraint_solver.island_state,
@@ -2842,6 +3040,46 @@ class RigidSolver(KinematicSolver):
             position, velocity, dofs_idx, envs_idx, self.dofs_state, self._static_rigid_sim_config
         )
 
+    def control_tendons_force(self, force, tendons_idx=None, envs_idx=None):
+        """Set the direct force control target for one or more (fixed) tendon actuators."""
+        force, tendons_idx, envs_idx = self._sanitize_io_variables(
+            force, tendons_idx, self.n_tendons, "tendons_idx", envs_idx, skip_allocation=True
+        )
+        if self.n_envs == 0:
+            force = force[None]
+        kernel_control_tendons_force(force, tendons_idx, envs_idx, self.tendons_state, self._static_rigid_sim_config)
+
+    def control_tendons_velocity(self, velocity, tendons_idx=None, envs_idx=None):
+        """Set the velocity control target for one or more (fixed) tendon actuators."""
+        velocity, tendons_idx, envs_idx = self._sanitize_io_variables(
+            velocity, tendons_idx, self.n_tendons, "tendons_idx", envs_idx, skip_allocation=True
+        )
+        if self.n_envs == 0:
+            velocity = velocity[None]
+        kernel_control_tendons_velocity(
+            velocity, tendons_idx, envs_idx, self.tendons_state, self._static_rigid_sim_config
+        )
+
+    def control_tendons_position(self, position, tendons_idx=None, envs_idx=None):
+        """Set the position (target length) control target for one or more (fixed) tendon actuators."""
+        position, tendons_idx, envs_idx = self._sanitize_io_variables(
+            position, tendons_idx, self.n_tendons, "tendons_idx", envs_idx, skip_allocation=True
+        )
+        if self.n_envs == 0:
+            position = position[None]
+        kernel_control_tendons_position(
+            position, tendons_idx, envs_idx, self.tendons_state, self._static_rigid_sim_config
+        )
+
+    def get_tendons_length(self, tendons_idx=None, envs_idx=None):
+        """Return the current length ``L = sum_i coef_i * qpos_i`` of one or more (fixed) tendons."""
+        _tensor, tendons_idx, envs_idx = self._sanitize_io_variables(
+            None, tendons_idx, self.n_tendons, "tendons_idx", envs_idx
+        )
+        tensor = _tensor[None] if self.n_envs == 0 else _tensor
+        kernel_get_tendons_length(tensor, tendons_idx, envs_idx, self.tendons_state, self._static_rigid_sim_config)
+        return _tensor
+
     def get_sol_params(self, geoms_idx=None, envs_idx=None, *, joints_idx=None, eqs_idx=None):
         """
         Get constraint solver parameters.
@@ -3329,6 +3567,30 @@ class RigidSolver(KinematicSolver):
             return self._equalities
         return gs.List(equality for entity in self._entities for equality in entity.equalities)
 
+    @property
+    def n_tendons(self):
+        if self.is_built:
+            return self._n_tendons
+        return sum(entity.n_tendons for entity in self._entities)
+
+    @property
+    def tendons(self):
+        if self.is_built:
+            return self._tendons
+        return gs.List(tendon for entity in self._entities for tendon in entity.tendons)
+
+    @property
+    def n_sites(self):
+        if self.is_built:
+            return self._n_sites
+        return sum(entity.n_sites for entity in self._entities)
+
+    @property
+    def sites(self):
+        if self.is_built:
+            return self._sites
+        return gs.List(site for entity in self._entities for site in entity.sites)
+
 
 @qd.kernel(fastcache=True)
 def kernel_step_1(
@@ -3342,6 +3604,9 @@ def kernel_step_1(
     geoms_info: array_class.GeomsInfo,
     entities_state: array_class.EntitiesState,
     entities_info: array_class.EntitiesInfo,
+    sites_info: array_class.SitesInfo,
+    tendons_info: array_class.TendonsInfo,
+    tendons_state: array_class.TendonsState,
     rigid_global_info: array_class.RigidGlobalInfo,
     static_rigid_sim_config: qd.template(),
     island_state: array_class.IslandState,
@@ -3387,6 +3652,10 @@ def kernel_step_1(
         entities_state=entities_state,
         entities_info=entities_info,
         geoms_state=geoms_state,
+        geoms_info=geoms_info,
+        sites_info=sites_info,
+        tendons_info=tendons_info,
+        tendons_state=tendons_state,
         rigid_global_info=rigid_global_info,
         static_rigid_sim_config=static_rigid_sim_config,
         island_state=island_state,

--- a/genesis/utils/array_class.py
+++ b/genesis/utils/array_class.py
@@ -721,10 +721,14 @@ def get_island_state(solver, collider):
     )
     max_candidate_contacts = max(collider._collider_info.max_candidate_contacts[None], 1)
     # Safe upper bound on active constraints, mirroring ConstraintSolver.len_constraints: 4 per contact +
-    # joint-limit/frictionloss (<= n_dofs each) + equality rows (<= 6 each). The equality term must use the
-    # candidate count (model equalities plus the dynamic-weld budget), not just the model equalities, otherwise
-    # constraint_id is undersized once dynamic welds are added and the per-island grouping writes out of bounds.
-    n_constraints_max = max(max_candidate_contacts * 4 + 2 * n_dofs + max(solver.n_candidate_equalities_, 1) * 6, 1)
+    # joint-limit/frictionloss (<= n_dofs each) + equality rows (<= 6 each) + tendon limit/frictionloss rows
+    # (<= n_tendons each). The equality term must use the candidate count (model equalities plus the dynamic-weld
+    # budget), not just the model equalities, otherwise constraint_id is undersized once dynamic welds are added and
+    # the per-island grouping writes out of bounds.
+    n_constraints_max = max(
+        max_candidate_contacts * 4 + 2 * n_dofs + max(solver.n_candidate_equalities_, 1) * 6 + 2 * solver.n_tendons_,
+        1,
+    )
     return IslandState(
         links_parent_idx=V(dtype=gs.qd_int, shape=maybe_shape((n_links, _B), is_active)),
         links_island_idx=V(dtype=gs.qd_int, shape=maybe_shape((n_links, _B), is_active)),
@@ -2170,6 +2174,145 @@ def get_equalities_info(solver):
     )
 
 
+# =========================================== SitesInfo ===========================================
+
+
+@dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
+class SitesInfo:
+    # Persistent site table (a site is a frame rigidly attached to a link). Used by spatial tendons; world positions are
+    # recomputed each step from the owning link's transform.
+    link_idx: qd.Tensor  # (n_sites_,) owning link
+    pos: qd.Tensor  # (n_sites_,) vec3 local position in link frame
+    quat: qd.Tensor  # (n_sites_,) vec4 local orientation in link frame
+
+
+def get_sites_info(solver):
+    shape = (max(solver.n_sites_, 1),)
+    return SitesInfo(
+        link_idx=V(dtype=gs.qd_int, shape=shape),
+        pos=V(dtype=gs.qd_vec3, shape=shape),
+        quat=V(dtype=gs.qd_vec4, shape=shape),
+    )
+
+
+# =========================================== TendonsInfo ===========================================
+
+
+@dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
+class TendonsInfo:
+    # Static per-tendon parameters. A tendon exposes a scalar length whose moment arm w.r.t. each DOF is recomputed
+    # each step into TendonsState.moment. For a FIXED tendon the length is L = sum_i coef_i * qpos_i and the moment is
+    # the constant coef; for a SPATIAL tendon the length is the geometric path length and the moment is computed from
+    # point Jacobians. Both share the `dof_idx` "relevant DOF" list (members for fixed; union of path-body parent
+    # chains for spatial) so all downstream (passive/actuator/constraints) is agnostic to the kind.
+    kind: qd.Tensor  # (n_tendons_,) gs.TENDON_TYPE
+    n_members: qd.Tensor  # (n_tendons_,) number of relevant DOFs
+    dof_idx: qd.Tensor  # (n_tendons_, max_members) global DOF index of each relevant DOF
+    coef: qd.Tensor  # (n_tendons_, max_members) fixed-tendon coefficient (unused for spatial)
+    q_idx: qd.Tensor  # (n_tendons_, max_members) global qpos index (fixed only)
+    # Spatial wrap path (ordered list of SITE / PULLEY / SPHERE / CYLINDER elements)
+    n_wraps: qd.Tensor  # (n_tendons_,)
+    wrap_type: qd.Tensor  # (n_tendons_, max_wraps) gs.WRAP_TYPE
+    wrap_objid: qd.Tensor  # (n_tendons_, max_wraps) global site idx for SITE elements; else -1
+    wrap_prm: qd.Tensor  # (n_tendons_, max_wraps) pulley divisor (PULLEY elements); else 0
+    wrap_sideid: qd.Tensor  # (n_tendons_, max_wraps) sidesite global site idx for SPHERE/CYLINDER; else -1
+    # Wrap geom (SPHERE/CYLINDER elements): stored as a frame on a link so the world pose is recomputed each step,
+    # independent of whether the geom collides (wrap geoms are usually non-colliding, i.e. visual-only in Genesis).
+    wrap_geom_link: qd.Tensor  # (n_tendons_, max_wraps) owning link; else -1
+    wrap_geom_pos: qd.Tensor  # (n_tendons_, max_wraps) vec3 local position of the geom in its link frame
+    wrap_geom_quat: qd.Tensor  # (n_tendons_, max_wraps) vec4 local orientation of the geom in its link frame
+    wrap_geom_radius: qd.Tensor  # (n_tendons_, max_wraps) wrap radius
+    # Passive dynamics
+    stiffness: qd.Tensor  # (n_tendons_,)
+    damping: qd.Tensor
+    springlength: qd.Tensor  # (n_tendons_,) vec2 deadband [lo, hi]; force is zero inside [lo, hi]
+    frictionloss: qd.Tensor
+    # Length limits
+    limited: qd.Tensor  # (n_tendons_,) int flag
+    limit: qd.Tensor  # (n_tendons_,) vec2 [lo, hi]
+    sol_params: qd.Tensor  # (n_tendons_,) vec7 solref/solimp for frictionloss
+    sol_params_limit: qd.Tensor  # (n_tendons_,) vec7 solref/solimp for limits
+    # Actuator transmission (affine: force = act_gain * ctrl + bias0 + bias1 * L + bias2 * V)
+    act_gain: qd.Tensor  # (n_tendons_,)
+    act_bias: qd.Tensor  # (n_tendons_,) vec3
+    force_range: qd.Tensor  # (n_tendons_,) vec2
+    length0: qd.Tensor  # (n_tendons_,) reference length at qpos0 (used by tendon equality constraints)
+
+
+def get_tendons_info(solver):
+    n_tendons = max(solver.n_tendons_, 1)
+    max_members = max(solver.tendon_max_members_, 1)
+    max_wraps = max(solver.tendon_max_wraps_, 1)
+    shape = (n_tendons,)
+    shape_members = (n_tendons, max_members)
+    shape_wraps = (n_tendons, max_wraps)
+
+    return TendonsInfo(
+        kind=V(dtype=gs.qd_int, shape=shape),
+        n_members=V(dtype=gs.qd_int, shape=shape),
+        dof_idx=V(dtype=gs.qd_int, shape=shape_members),
+        coef=V(dtype=gs.qd_float, shape=shape_members),
+        q_idx=V(dtype=gs.qd_int, shape=shape_members),
+        n_wraps=V(dtype=gs.qd_int, shape=shape),
+        wrap_type=V(dtype=gs.qd_int, shape=shape_wraps),
+        wrap_objid=V(dtype=gs.qd_int, shape=shape_wraps),
+        wrap_prm=V(dtype=gs.qd_float, shape=shape_wraps),
+        wrap_sideid=V(dtype=gs.qd_int, shape=shape_wraps),
+        wrap_geom_link=V(dtype=gs.qd_int, shape=shape_wraps),
+        wrap_geom_pos=V(dtype=gs.qd_vec3, shape=shape_wraps),
+        wrap_geom_quat=V(dtype=gs.qd_vec4, shape=shape_wraps),
+        wrap_geom_radius=V(dtype=gs.qd_float, shape=shape_wraps),
+        stiffness=V(dtype=gs.qd_float, shape=shape),
+        damping=V(dtype=gs.qd_float, shape=shape),
+        springlength=V(dtype=gs.qd_vec2, shape=shape),
+        frictionloss=V(dtype=gs.qd_float, shape=shape),
+        limited=V(dtype=gs.qd_int, shape=shape),
+        limit=V(dtype=gs.qd_vec2, shape=shape),
+        sol_params=V(dtype=gs.qd_vec7, shape=shape),
+        sol_params_limit=V(dtype=gs.qd_vec7, shape=shape),
+        act_gain=V(dtype=gs.qd_float, shape=shape),
+        act_bias=V(dtype=gs.qd_vec3, shape=shape),
+        force_range=V(dtype=gs.qd_vec2, shape=shape),
+        length0=V(dtype=gs.qd_float, shape=shape),
+    )
+
+
+# =========================================== TendonsState ===========================================
+
+
+@dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
+class TendonsState:
+    length: qd.Tensor  # (n_tendons_, _B)
+    velocity: qd.Tensor
+    moment: qd.Tensor  # (n_tendons_, n_dofs_, _B) per-step moment arm w.r.t. each DOF
+    ctrl_force: qd.Tensor
+    ctrl_pos: qd.Tensor
+    ctrl_vel: qd.Tensor
+    ctrl_mode: qd.Tensor
+    # World-space path points of a spatial tendon (sites + geom-wrap points), for debug visualization.
+    path_pos: qd.Tensor  # (n_tendons_, max_path_points, _B) vec3
+    path_num: qd.Tensor  # (n_tendons_, _B) number of valid path points (0 for fixed tendons)
+
+
+def get_tendons_state(solver):
+    shape = (max(solver.n_tendons_, 1), solver._B)
+    shape_moment = (max(solver.n_tendons_, 1), solver.n_dofs_, solver._B)
+    shape_path = (max(solver.n_tendons_, 1), max(solver.tendon_max_path_points_, 1), solver._B)
+    requires_grad = solver._requires_grad
+
+    return TendonsState(
+        length=V(dtype=gs.qd_float, shape=shape, needs_grad=requires_grad),
+        velocity=V(dtype=gs.qd_float, shape=shape, needs_grad=requires_grad),
+        moment=V(dtype=gs.qd_float, shape=shape_moment, needs_grad=requires_grad),
+        ctrl_force=V(dtype=gs.qd_float, shape=shape, needs_grad=requires_grad),
+        ctrl_pos=V(dtype=gs.qd_float, shape=shape, needs_grad=requires_grad),
+        ctrl_vel=V(dtype=gs.qd_float, shape=shape, needs_grad=requires_grad),
+        ctrl_mode=V(dtype=gs.qd_int, shape=shape),
+        path_pos=V(dtype=gs.qd_vec3, shape=shape_path),
+        path_num=V(dtype=gs.qd_int, shape=shape),
+    )
+
+
 # =========================================== EntitiesInfo ===========================================
 
 
@@ -2269,6 +2412,7 @@ class RigidSimStaticConfig(metaclass=AutoInitMeta):
     solver_type: int
     requires_grad: bool
     prefer_decomposed_solver: int = -1  # -1 = None (auto), 0 = False, 1 = True
+    n_tendons: int = 0  # number of fixed tendons; static loop bound for the tendon force/constraint kernels
     use_contact_island: bool = False  # per-island Newton solve (gated; the legacy island solver is retired)
     # Consecutive sub-tolerance steps a body's max DOF velocity must hold before it is ready to hibernate. Guards
     # against a body that is only momentarily slow (e.g. at the apex of a toss) sleeping prematurely.
@@ -2368,6 +2512,9 @@ class DataManager:
             self.fixed_verts_state = get_fixed_verts_state(solver)
 
             self.equalities_info = get_equalities_info(solver)
+            self.sites_info = get_sites_info(solver)
+            self.tendons_info = get_tendons_info(solver)
+            self.tendons_state = get_tendons_state(solver)
 
         if solver._static_rigid_sim_config.requires_grad:
             # Data structures required for backward pass

--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -2,7 +2,6 @@ import os
 import xml.etree.ElementTree as ET
 from pathlib import Path
 from itertools import chain
-from bisect import bisect_right
 
 # Note the importing mujoco with env var `MUJOCO_GL=EGL` forcibly defines `PYOPENGL_PLATFORM=egl`
 import mujoco
@@ -219,11 +218,6 @@ def parse_xml(morph, surface):
     # Build model from XML (either URDF or MJCF)
     mj = build_model(morph.file, not morph.visualization, morph.default_armature, merge_fixed_links, links_to_keep)
 
-    # We have another more informative warning later so we suppress this one
-    # gs.logger.warning(f"(MJCF) Approximating tendon by joint actuator for `{j_info['name']}`")
-    # if mj.ntendon:
-    #     gs.logger.warning("(MJCF) Tendon not supported")
-
     # Parse all geometries grouped by parent joint (or world)
     links_g_infos = parse_geoms(mj, morph.scale, surface, morph.file)
 
@@ -236,7 +230,11 @@ def parse_xml(morph, surface):
     # Parsing all equality constraints
     eqs_info = parse_equalities(mj, morph.scale)
 
-    return l_infos, links_j_infos, links_g_infos, eqs_info
+    # Parsing sites (persistent table) and tendons (fixed + spatial)
+    sites_info = parse_sites(mj, morph.scale)
+    tendons_info = parse_tendons(mj, morph.scale)
+
+    return l_infos, links_j_infos, links_g_infos, eqs_info, tendons_info, sites_info
 
 
 def parse_link(mj, i_l, scale):
@@ -361,22 +359,15 @@ def parse_link(mj, i_l, scale):
         j_info["dofs_act_bias"] = np.zeros((n_dofs, 3), dtype=gs.np_float)
         j_info["dofs_force_range"] = np.tile([-np.inf, np.inf], (n_dofs, 1))
 
+        # Only actuators attached directly to this joint via mechanical transmission are folded into the joint's
+        # per-DOF actuator params here. Tendon-transmission actuators (mjTRN_TENDON) are handled separately by
+        # `parse_tendons` / the tendon subsystem, so they must NOT be baked onto a joint (that would double-apply
+        # the force).
         i_a = -1
         try:
             actuator_mask_j = (mj.actuator_trnid[:, 0] == i_j) & (mj.actuator_trntype == mujoco.mjtTrn.mjTRN_JOINT)
             if actuator_mask_j.any():
                 (i_a,) = np.nonzero(actuator_mask_j)[0]
-            else:  # No actuator directly attached to the joint via mechanical transmission
-                # Special case where all tendon are attached to joint. Very common in practice.
-                if (mj.wrap_type == mujoco.mjtWrap.mjWRAP_JOINT).all():
-                    if i_j in mj.wrap_objid:
-                        (m,) = np.nonzero(mj.wrap_objid == i_j)[0]
-                        i_t = bisect_right(np.cumsum(mj.tendon_num), m)
-                        actuator_mask_t = (mj.actuator_trnid[:, 0] == i_t) & (
-                            mj.actuator_trntype == mujoco.mjtTrn.mjTRN_TENDON
-                        )
-                        (i_a,) = np.nonzero(actuator_mask_t)[0]
-                        gs.logger.warning(f"(MJCF) Approximating tendon by joint actuator for `{j_info['name']}`")
         except ValueError:
             gs.logger.warning(f"(MJCF) Failed to parse actuator for joint `{j_info['name']}`.")
 
@@ -785,6 +776,8 @@ def parse_equalities(mj, scale):
                 eq_info["data"][:3], eq_info["data"][3:6] = (sites_pos[0], sites_pos[1])
         elif mj.eq_type[i_e] == mujoco.mjtEq.mjEQ_JOINT:
             name_objadr = mj.name_jntadr
+        elif mj.eq_type[i_e] == mujoco.mjtEq.mjEQ_TENDON:
+            name_objadr = mj.name_tendonadr
         elif mj.eq_objtype[i_e] == mujoco.mjtObj.mjOBJ_BODY:
             name_objadr = mj.name_bodyadr
         else:
@@ -799,6 +792,9 @@ def parse_equalities(mj, scale):
         elif mj.eq_type[i_e] == mujoco.mjtEq.mjEQ_JOINT:
             # y -y0 = a0 + a1 * (x-x0) + a2 * (x-x0)^2 + a3 * (x-x0)^3 + a4 * (x-x0)^4
             eq_info["type"] = gs.EQUALITY_TYPE.JOINT
+        elif mj.eq_type[i_e] == mujoco.mjtEq.mjEQ_TENDON:
+            # Same quartic coupling as JOINT, but between two tendon lengths (relative to their reference lengths).
+            eq_info["type"] = gs.EQUALITY_TYPE.TENDON
         else:
             gs.raise_exception(f"Unsupported MJCF equality type: {mj.eq_type[i_e]}")
 
@@ -815,3 +811,148 @@ def parse_equalities(mj, scale):
         eqs_info.append(eq_info)
 
     return eqs_info
+
+
+def _mj_name(mj, name_adr_array, idx):
+    if idx < 0:
+        return None
+    name_start = name_adr_array[idx]
+    name, *_ = mj.names[name_start:].decode("utf-8").split("\x00")
+    return name
+
+
+def parse_sites(mj, scale):
+    """Parse MuJoCo sites into a persistent table (a site is a frame rigidly attached to a body/link).
+
+    Sites are used by spatial tendons and equality constraints. Each entry records the owning body's name (resolved to
+    a Genesis link at build time) and the site's local pose in that body frame.
+    """
+    sites_info = []
+    for i_s in range(mj.nsite):
+        s_info = dict()
+        s_info["name"] = _mj_name(mj, mj.name_siteadr, i_s)
+        s_info["body_name"] = _mj_name(mj, mj.name_bodyadr, int(mj.site_bodyid[i_s]))
+        s_info["pos"] = np.asarray(mj.site_pos[i_s], dtype=gs.np_float) * scale
+        s_info["quat"] = np.asarray(mj.site_quat[i_s], dtype=gs.np_float)
+        sites_info.append(s_info)
+    return sites_info
+
+
+def _parse_tendon_actuator(mj, i_t, tendon_name, scale):
+    """Parse the (optional) actuator whose transmission is this tendon. Returns (act_gain, act_bias(3), force_range(2)).
+
+    MuJoCo affine model (matching the per-joint actuator parsing in `parse_link`):
+        force = gainprm[0] * ctrl + biasprm[0] + biasprm[1] * L + biasprm[2] * V
+    """
+    act_gain = 0.0
+    act_bias = np.zeros(3, dtype=gs.np_float)
+    force_range = np.array([-np.inf, np.inf], dtype=gs.np_float)
+    actuator_mask = (mj.actuator_trntype == mujoco.mjtTrn.mjTRN_TENDON) & (mj.actuator_trnid[:, 0] == i_t)
+    i_a_list = np.nonzero(actuator_mask)[0]
+    if len(i_a_list) > 1:
+        gs.logger.warning(f"(MJCF) Multiple actuators on tendon `{tendon_name}`; only the first is used.")
+    for i_a in i_a_list[:1]:
+        if mj.actuator_dyntype[i_a] != mujoco.mjtDyn.mjDYN_NONE:
+            gs.logger.warning("(MJCF) Actuator internal dynamics not supported")
+        gaintype = mujoco.mjtGain(mj.actuator_gaintype[i_a])
+        if gaintype != mujoco.mjtGain.mjGAIN_FIXED:
+            gs.logger.warning(f"(MJCF) Actuator control gain of type '{gaintype}' not supported")
+        biastype = mujoco.mjtBias(mj.actuator_biastype[i_a])
+        if biastype not in (mujoco.mjtBias.mjBIAS_NONE, mujoco.mjtBias.mjBIAS_AFFINE):
+            gs.logger.warning(f"(MJCF) Actuator control bias of type '{biastype}' not supported")
+        gear = float(mj.actuator_gear[i_a, 0])
+        act_gain = float(gear * mj.actuator_gainprm[i_a, 0] * scale**3)
+        if biastype != mujoco.mjtBias.mjBIAS_NONE:
+            act_bias = (gear * mj.actuator_biasprm[i_a, :3] * scale**3).astype(gs.np_float)
+        if mj.actuator_forcelimited[i_a]:
+            force_range = np.asarray(mj.actuator_forcerange[i_a], dtype=gs.np_float).copy()
+    return act_gain, act_bias, force_range
+
+
+def parse_tendons(mj, scale):
+    """Parse MuJoCo tendons (fixed and spatial) and their actuator transmissions.
+
+    A FIXED tendon has length ``L = sum_i coef_i * qpos_i`` over its member joints, so its moment arm w.r.t. each
+    member DOF is the constant coefficient ``coef_i``. A SPATIAL tendon is a geometric path routed through sites,
+    wrapping around sphere/cylinder geoms, and split by pulleys; its length and moment arms are configuration
+    dependent and computed each step from link/geom kinematics.
+    """
+    tendons_info = []
+    for i_t in range(mj.ntendon):
+        adr = mj.tendon_adr[i_t]
+        num = mj.tendon_num[i_t]
+        wrap_types = mj.wrap_type[adr : adr + num]
+        tendon_name = _mj_name(mj, mj.name_tendonadr, i_t)
+
+        is_fixed = (wrap_types == mujoco.mjtWrap.mjWRAP_JOINT).all()
+
+        t_info = dict()
+        t_info["name"] = tendon_name
+        t_info["stiffness"] = float(mj.tendon_stiffness[i_t])
+        t_info["damping"] = float(mj.tendon_damping[i_t])
+        t_info["frictionloss"] = float(mj.tendon_frictionloss[i_t])
+        # `lengthspring` is the [lo, hi] deadband of the passive spring rest length (a single value in older MuJoCo).
+        springlength = np.atleast_1d(np.asarray(mj.tendon_lengthspring[i_t], dtype=gs.np_float).ravel())
+        if springlength.size == 1:
+            springlength = np.array([springlength[0], springlength[0]], dtype=gs.np_float)
+        t_info["springlength"] = springlength[:2] * (scale if not is_fixed else 1.0)
+        t_info["limited"] = bool(mj.tendon_limited[i_t])
+        # Spatial tendon length is a distance (scale it); fixed tendon length is in joint coordinates (do not scale).
+        t_info["limit"] = np.asarray(mj.tendon_range[i_t], dtype=gs.np_float) * (scale if not is_fixed else 1.0)
+        t_info["sol_params"] = np.concatenate((mj.tendon_solref_fri[i_t], mj.tendon_solimp_fri[i_t]))
+        t_info["sol_params_limit"] = np.concatenate((mj.tendon_solref_lim[i_t], mj.tendon_solimp_lim[i_t]))
+        act_gain, act_bias, force_range = _parse_tendon_actuator(mj, i_t, tendon_name, scale)
+        t_info["act_gain"] = act_gain
+        t_info["act_bias"] = act_bias
+        t_info["force_range"] = force_range
+        # Reference length at qpos0 (MuJoCo computes it at compile time). Distance for spatial, joint-coords for fixed.
+        t_info["length0"] = float(mj.tendon_length0[i_t]) * (scale if not is_fixed else 1.0)
+
+        if is_fixed:
+            t_info["kind"] = gs.TENDON_TYPE.FIXED
+            members = []
+            for k in range(num):
+                i_j = int(mj.wrap_objid[adr + k])
+                coef = float(mj.wrap_prm[adr + k])
+                members.append((_mj_name(mj, mj.name_jntadr, i_j), coef))
+            t_info["members"] = members
+            t_info["wraps"] = []
+        else:
+            t_info["kind"] = gs.TENDON_TYPE.SPATIAL
+            t_info["members"] = []
+            wraps = []
+            for k in range(num):
+                wt = mj.wrap_type[adr + k]
+                if wt == mujoco.mjtWrap.mjWRAP_SITE:
+                    wraps.append(
+                        {
+                            "type": gs.WRAP_TYPE.SITE,
+                            "site_name": _mj_name(mj, mj.name_siteadr, int(mj.wrap_objid[adr + k])),
+                        }
+                    )
+                elif wt == mujoco.mjtWrap.mjWRAP_PULLEY:
+                    wraps.append({"type": gs.WRAP_TYPE.PULLEY, "divisor": float(mj.wrap_prm[adr + k])})
+                elif wt in (mujoco.mjtWrap.mjWRAP_SPHERE, mujoco.mjtWrap.mjWRAP_CYLINDER):
+                    kind = gs.WRAP_TYPE.SPHERE if wt == mujoco.mjtWrap.mjWRAP_SPHERE else gs.WRAP_TYPE.CYLINDER
+                    sideid = int(round(float(mj.wrap_prm[adr + k])))
+                    i_g = int(mj.wrap_objid[adr + k])
+                    # Read the wrap geom's local frame + radius directly from MuJoCo (wrap geoms are typically
+                    # non-colliding, so they are not tracked as Genesis collision geoms). The world pose is recomputed
+                    # each step from the owning link's transform.
+                    wraps.append(
+                        {
+                            "type": kind,
+                            "geom_body_name": _mj_name(mj, mj.name_bodyadr, int(mj.geom_bodyid[i_g])),
+                            "geom_pos": np.asarray(mj.geom_pos[i_g], dtype=gs.np_float) * scale,
+                            "geom_quat": np.asarray(mj.geom_quat[i_g], dtype=gs.np_float),
+                            "geom_radius": float(mj.geom_size[i_g, 0]) * scale,
+                            "side_name": _mj_name(mj, mj.name_siteadr, sideid) if sideid >= 0 else None,
+                        }
+                    )
+                else:
+                    gs.raise_exception(f"(MJCF) Unsupported wrap element type {wt} in tendon `{tendon_name}`.")
+            t_info["wraps"] = wraps
+
+        tendons_info.append(t_info)
+
+    return tendons_info

--- a/genesis/utils/urdf.py
+++ b/genesis/utils/urdf.py
@@ -405,7 +405,10 @@ def parse_urdf(morph, surface):
 
     eqs_info = parse_equalities(robot, morph)
 
-    return l_infos, links_j_infos, links_g_infos, eqs_info
+    tendons_info = []  # URDF does not support tendons
+    sites_info = []  # URDF does not support sites
+
+    return l_infos, links_j_infos, links_g_infos, eqs_info, tendons_info, sites_info
 
 
 def parse_equalities(robot, morph):

--- a/genesis/utils/usd/usd_rigid_entity.py
+++ b/genesis/utils/usd/usd_rigid_entity.py
@@ -678,5 +678,7 @@ def parse_usd_rigid_entity(morph: gs.morphs.USD, surface: gs.surfaces.Surface):
     l_infos, links_j_infos = _parse_links(context, links, link_joints, morph)
     l_infos, links_j_infos, links_g_infos, _ = urdf_utils.order_links_depth_first(l_infos, links_j_infos, links_g_infos)
     eqs_info = []  # USD doesn't support equality constraints
+    tendons_info = []  # USD doesn't support tendons
+    sites_info = []  # USD doesn't support sites
 
-    return l_infos, links_j_infos, links_g_infos, eqs_info
+    return l_infos, links_j_infos, links_g_infos, eqs_info, tendons_info, sites_info

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -26,6 +26,7 @@ from genesis.engine.states.solvers import RigidSolverState
 from genesis.utils.misc import get_assets_dir, qd_to_numpy, qd_to_torch, tensor_to_array
 
 from .utils import (
+    _get_model_mappings,
     assert_allclose,
     assert_equal,
     check_mujoco_data_consistency,
@@ -79,6 +80,158 @@ def mimic_hinges():
     ET.SubElement(child2, "joint", type="hinge", name="joint2", axis="0 1 0", range="-45 45")
     equality = ET.SubElement(mjcf, "equality")
     ET.SubElement(equality, "joint", name="joint_equality", joint1="joint1", joint2="joint2")
+    return mjcf
+
+
+def _two_hinge_tendon_model(name, tendon_attrs):
+    """Two hinges coupled by a fixed tendon `t1` (coef 1 each). `tendon_attrs` sets the <fixed> element attributes."""
+    mjcf = ET.Element("mujoco", model=name)
+    ET.SubElement(mjcf, "compiler", angle="radian")
+    ET.SubElement(mjcf, "option", timestep="0.01")
+    worldbody = ET.SubElement(mjcf, "worldbody")
+    parent = ET.SubElement(worldbody, "body", name="parent", pos="0 0 1.0")
+    child1 = ET.SubElement(parent, "body", name="child1", pos="0.5 0 0")
+    ET.SubElement(child1, "geom", type="capsule", size="0.05 0.2", rgba="0.9 0.1 0.1 1")
+    ET.SubElement(child1, "joint", type="hinge", name="joint1", axis="0 1 0", range="-2 2")
+    child2 = ET.SubElement(parent, "body", name="child2", pos="0 0.5 0")
+    ET.SubElement(child2, "geom", type="capsule", size="0.05 0.2", rgba="0.1 0.1 0.9 1")
+    ET.SubElement(child2, "joint", type="hinge", name="joint2", axis="0 1 0", range="-2 2")
+    tendon = ET.SubElement(mjcf, "tendon")
+    fixed = ET.SubElement(tendon, "fixed", name="t1", **tendon_attrs)
+    ET.SubElement(fixed, "joint", joint="joint1", coef="1")
+    ET.SubElement(fixed, "joint", joint="joint2", coef="1")
+    return mjcf
+
+
+@pytest.fixture(scope="session")
+def tendon_spring():
+    # Fixed tendon with a passive spring (rest length 0) coupling the two hinges. Stiffness is a position-dependent
+    # (explicit) force in both MuJoCo and Genesis, so this matches under both Euler and implicitfast.
+    return _two_hinge_tendon_model("tendon_spring", {"stiffness": "30", "springlength": "0"})
+
+
+@pytest.fixture(scope="session")
+def tendon_damped():
+    # Fixed tendon with passive damping. Genesis applies tendon damping explicitly, so this matches MuJoCo exactly
+    # only under the Euler integrator (MuJoCo integrates tendon damping implicitly under implicitfast).
+    return _two_hinge_tendon_model("tendon_damped", {"stiffness": "20", "damping": "3", "springlength": "0"})
+
+
+@pytest.fixture(scope="session")
+def tendon_limit():
+    # Fixed tendon with a length limit; the coupled hinges must not let (joint1 + joint2) leave [-0.5, 0.5].
+    return _two_hinge_tendon_model("tendon_limit", {"limited": "true", "range": "-0.5 0.5"})
+
+
+def _spatial_arm_base(name):
+    """Two-hinge planar arm with sites for routing a spatial tendon; returns (mjcf, worldbody, b2)."""
+    mjcf = ET.Element("mujoco", model=name)
+    ET.SubElement(mjcf, "compiler", angle="radian")
+    ET.SubElement(mjcf, "option", timestep="0.002")
+    worldbody = ET.SubElement(mjcf, "worldbody")
+    ET.SubElement(worldbody, "site", name="s0", pos="0.4 0 0.6")
+    b1 = ET.SubElement(worldbody, "body", name="b1", pos="0 0 0.5")
+    ET.SubElement(b1, "joint", name="j1", type="hinge", axis="0 1 0")
+    ET.SubElement(b1, "geom", type="capsule", fromto="0 0 0 0.3 0 0", size="0.03", mass="0.2")
+    ET.SubElement(b1, "site", name="s1", pos="0.15 0 0.05")
+    b2 = ET.SubElement(b1, "body", name="b2", pos="0.3 0 0")
+    ET.SubElement(b2, "joint", name="j2", type="hinge", axis="0 1 0")
+    ET.SubElement(b2, "geom", type="capsule", fromto="0 0 0 0.3 0 0", size="0.03", mass="0.2")
+    ET.SubElement(b2, "site", name="s2", pos="0.15 0 0.05")
+    return mjcf, worldbody, b2
+
+
+@pytest.fixture(scope="session")
+def tendon_spatial():
+    # Spatial tendon routed through 3 sites (world -> link1 -> link2) with a passive spring + damping.
+    mjcf, worldbody, b2 = _spatial_arm_base("tendon_spatial")
+    tendon = ET.SubElement(mjcf, "tendon")
+    sp = ET.SubElement(tendon, "spatial", name="t", stiffness="50", damping="0.5")
+    ET.SubElement(sp, "site", site="s0")
+    ET.SubElement(sp, "site", site="s1")
+    ET.SubElement(sp, "site", site="s2")
+    return mjcf
+
+
+@pytest.fixture(scope="session")
+def tendon_spatial_pulley():
+    # Spatial tendon with two branches joined by a pulley (divisor 2) and a passive spring.
+    mjcf, worldbody, b2 = _spatial_arm_base("tendon_spatial_pulley")
+    ET.SubElement(worldbody, "site", name="s3", pos="0.0 0 0.9")
+    ET.SubElement(b2, "site", name="s4", pos="0.05 0 0.05")
+    tendon = ET.SubElement(mjcf, "tendon")
+    sp = ET.SubElement(tendon, "spatial", name="t", stiffness="40", damping="0.5")
+    ET.SubElement(sp, "site", site="s0")
+    ET.SubElement(sp, "site", site="s2")
+    ET.SubElement(sp, "pulley", divisor="2")
+    ET.SubElement(sp, "site", site="s3")
+    ET.SubElement(sp, "site", site="s4")
+    return mjcf
+
+
+def _tendon_wrap_model(name, geomtype):
+    # A hinge pendulum whose spatial tendon (world site -> tip site) wraps over a fixed obstacle geom between them.
+    mjcf = ET.Element("mujoco", model=name)
+    ET.SubElement(mjcf, "compiler", angle="radian")
+    ET.SubElement(mjcf, "option", timestep="0.002")
+    worldbody = ET.SubElement(mjcf, "worldbody")
+    ET.SubElement(worldbody, "site", name="s0", pos="-0.3 0 0.5")
+    ET.SubElement(
+        worldbody, "geom", name="obstacle", type=geomtype, pos="0 0 0.5", size="0.1 0.4", contype="0", conaffinity="0"
+    )
+    b1 = ET.SubElement(worldbody, "body", name="b1", pos="0 0 0.5")
+    ET.SubElement(b1, "joint", name="j1", type="hinge", axis="0 1 0")
+    ET.SubElement(
+        b1, "geom", type="capsule", fromto="0 0 0 0.4 0 0", size="0.02", mass="0.2", contype="0", conaffinity="0"
+    )
+    ET.SubElement(b1, "site", name="s1", pos="0.4 0 0")
+    tendon = ET.SubElement(mjcf, "tendon")
+    sp = ET.SubElement(tendon, "spatial", name="t", stiffness="30", damping="0.3")
+    ET.SubElement(sp, "site", site="s0")
+    ET.SubElement(sp, "geom", geom="obstacle")
+    ET.SubElement(sp, "site", site="s1")
+    return mjcf
+
+
+@pytest.fixture(scope="session")
+def tendon_wrap_sphere():
+    return _tendon_wrap_model("tendon_wrap_sphere", "sphere")
+
+
+@pytest.fixture(scope="session")
+def tendon_wrap_cylinder():
+    return _tendon_wrap_model("tendon_wrap_cylinder", "cylinder")
+
+
+@pytest.fixture(scope="session")
+def tendon_equality():
+    # Two single-joint fixed tendons coupled by a tendon-tendon equality constraint (length1 == length2).
+    mjcf = ET.Element("mujoco", model="tendon_equality")
+    ET.SubElement(mjcf, "compiler", angle="radian")
+    ET.SubElement(mjcf, "option", timestep="0.005")
+    worldbody = ET.SubElement(mjcf, "worldbody")
+    b1 = ET.SubElement(worldbody, "body", name="b1", pos="0 0 1")
+    ET.SubElement(b1, "joint", name="j1", type="hinge", axis="0 1 0")
+    ET.SubElement(b1, "geom", type="capsule", fromto="0 0 0 0.3 0 0", size="0.03", mass="0.3")
+    b2 = ET.SubElement(worldbody, "body", name="b2", pos="0 0.4 1")
+    ET.SubElement(b2, "joint", name="j2", type="hinge", axis="0 1 0")
+    ET.SubElement(b2, "geom", type="capsule", fromto="0 0 0 0.3 0 0", size="0.03", mass="0.3")
+    tendon = ET.SubElement(mjcf, "tendon")
+    t1 = ET.SubElement(tendon, "fixed", name="t1")
+    ET.SubElement(t1, "joint", joint="j1", coef="1")
+    t2 = ET.SubElement(tendon, "fixed", name="t2")
+    ET.SubElement(t2, "joint", joint="j2", coef="1")
+    equality = ET.SubElement(mjcf, "equality")
+    ET.SubElement(equality, "tendon", tendon1="t1", tendon2="t2")
+    return mjcf
+
+
+@pytest.fixture(scope="session")
+def tendon_actuated():
+    # Two hinges coupled by a fixed tendon driven by a single position actuator (as in the Shadow Hand fingers).
+    mjcf = _two_hinge_tendon_model("tendon_actuated", {})
+    actuator = ET.SubElement(mjcf, "actuator")
+    ET.SubElement(actuator, "position", name="a1", tendon="t1", kp="8")
     return mjcf
 
 
@@ -692,6 +845,130 @@ def test_equality_joint(gs_sim, mj_sim, gs_solver, tol):
     # check if the two joints are equal
     gs_qpos = gs_sim.rigid_solver.qpos.to_numpy()[:, 0]
     assert_allclose(gs_qpos[0], gs_qpos[1], tol=tol)
+
+
+@pytest.mark.parametrize("model_name", ["tendon_spring"])
+@pytest.mark.parametrize("gs_solver", [gs.constraint_solver.CG, gs.constraint_solver.Newton])
+@pytest.mark.parametrize("gs_integrator", [gs.integrator.implicitfast, gs.integrator.Euler])
+@pytest.mark.parametrize("backend", [gs.cpu])
+def test_tendon_spring(gs_sim, mj_sim, gs_solver, tol):
+    # There is one fixed tendon with a passive spring, and no equality constraint.
+    assert gs_sim.rigid_solver.n_tendons == 1
+    assert gs_sim.rigid_solver.n_equalities == 0
+
+    qpos = np.array((0.4, -0.9))
+    qvel = np.array((1.0, -0.3))
+    simulate_and_check_mujoco_consistency(gs_sim, mj_sim, qpos, qvel, num_steps=300, tol=tol)
+
+
+@pytest.mark.parametrize("model_name", ["tendon_damped"])
+@pytest.mark.parametrize("gs_solver", [gs.constraint_solver.CG, gs.constraint_solver.Newton])
+@pytest.mark.parametrize("gs_integrator", [gs.integrator.Euler])
+@pytest.mark.parametrize("backend", [gs.cpu])
+def test_tendon_damped(gs_sim, mj_sim, gs_solver, tol):
+    # Fixed tendon with passive spring + damping. Genesis applies tendon damping explicitly, so this is checked under
+    # the Euler integrator only (exact); under implicitfast it differs from MuJoCo's implicit damping integration.
+    assert gs_sim.rigid_solver.n_tendons == 1
+
+    qpos = np.array((0.4, -0.9))
+    qvel = np.array((1.0, -0.3))
+    simulate_and_check_mujoco_consistency(gs_sim, mj_sim, qpos, qvel, num_steps=300, tol=tol)
+
+
+@pytest.mark.parametrize("model_name", ["tendon_limit"])
+@pytest.mark.parametrize("gs_solver", [gs.constraint_solver.CG, gs.constraint_solver.Newton])
+@pytest.mark.parametrize("gs_integrator", [gs.integrator.implicitfast, gs.integrator.Euler])
+@pytest.mark.parametrize("backend", [gs.cpu])
+def test_tendon_limit(gs_sim, mj_sim, gs_solver, tol):
+    # One fixed tendon with a length limit; the initial velocity drives the tendon length into the limit.
+    assert gs_sim.rigid_solver.n_tendons == 1
+
+    qpos = np.array((0.0, 0.0))
+    qvel = np.array((1.5, 1.5))
+    simulate_and_check_mujoco_consistency(gs_sim, mj_sim, qpos, qvel, num_steps=200, tol=tol)
+
+    # The coupled tendon length (joint1 + joint2) must respect the [-0.5, 0.5] range (within the limit softness).
+    gs_qpos = gs_sim.rigid_solver.qpos.to_numpy()[:, 0]
+    assert gs_qpos[0] + gs_qpos[1] < 0.6
+
+
+@pytest.mark.parametrize("model_name", ["tendon_spatial", "tendon_spatial_pulley"])
+@pytest.mark.parametrize("gs_solver", [gs.constraint_solver.CG, gs.constraint_solver.Newton])
+@pytest.mark.parametrize("gs_integrator", [gs.integrator.Euler])
+@pytest.mark.parametrize("backend", [gs.cpu])
+def test_tendon_spatial(gs_sim, mj_sim, gs_solver, tol):
+    # Spatial tendon (site-routed path, optionally with a pulley) with a passive spring; the configuration-dependent
+    # length and moment arms must track MuJoCo. Damping is checked under Euler only (applied explicitly).
+    assert gs_sim.rigid_solver.n_tendons == 1
+
+    qpos = np.array((0.5, -0.3))
+    qvel = np.array((0.4, -0.2))
+    simulate_and_check_mujoco_consistency(gs_sim, mj_sim, qpos, qvel, num_steps=300, tol=tol)
+
+
+@pytest.mark.parametrize("model_name", ["tendon_wrap_sphere", "tendon_wrap_cylinder"])
+@pytest.mark.parametrize("gs_solver", [gs.constraint_solver.Newton])
+@pytest.mark.parametrize("gs_integrator", [gs.integrator.Euler])
+@pytest.mark.parametrize("backend", [gs.cpu])
+def test_tendon_wrap(gs_sim, mj_sim, gs_solver, tol):
+    # Spatial tendon wrapping over a sphere/cylinder geom. The wrap points, arc length, and moment arms must track
+    # MuJoCo's mju_wrap. The initial angle bends the straight path into the obstacle to force a wrap.
+    assert gs_sim.rigid_solver.n_tendons == 1
+
+    qpos = np.array((1.2,))
+    qvel = np.array((0.0,))
+    simulate_and_check_mujoco_consistency(gs_sim, mj_sim, qpos, qvel, num_steps=250, tol=tol)
+
+
+@pytest.mark.parametrize("model_name", ["tendon_equality"])
+@pytest.mark.parametrize("gs_solver", [gs.constraint_solver.CG, gs.constraint_solver.Newton])
+@pytest.mark.parametrize("gs_integrator", [gs.integrator.Euler])
+@pytest.mark.parametrize("backend", [gs.cpu])
+def test_tendon_equality(gs_sim, mj_sim, gs_solver, tol):
+    # Two single-joint fixed tendons coupled by a tendon-tendon equality (mjEQ_TENDON): length1 == length2.
+    assert gs_sim.rigid_solver.n_tendons == 2
+    assert gs_sim.rigid_solver.n_equalities == 1
+
+    qpos = np.array((0.3, -0.2))
+    qvel = np.array((1.0, -0.5))
+    simulate_and_check_mujoco_consistency(gs_sim, mj_sim, qpos, qvel, num_steps=300, tol=tol)
+
+    # The coupled tendon lengths (== joint angles here) must track each other.
+    gs_qpos = gs_sim.rigid_solver.qpos.to_numpy()[:, 0]
+    assert_allclose(gs_qpos[0], gs_qpos[1], tol=tol)
+
+
+@pytest.mark.parametrize("model_name", ["tendon_actuated"])
+@pytest.mark.parametrize("gs_solver", [gs.constraint_solver.CG, gs.constraint_solver.Newton])
+@pytest.mark.parametrize("gs_integrator", [gs.integrator.implicitfast, gs.integrator.Euler])
+@pytest.mark.parametrize("backend", [gs.cpu])
+def test_tendon_actuator(gs_sim, mj_sim, gs_solver):
+    # A single position actuator drives a fixed tendon whose length couples the two hinges (Shadow-Hand-style).
+    # NB: check_mujoco_model_consistency is intentionally not used here - it compares per-DOF actuator gains, which do
+    # not apply to a tendon-transmission actuator (the gain lives on the tendon, not on any joint DOF).
+    assert gs_sim.rigid_solver.n_tendons == 1
+
+    _, (_, _, mj_qs_idx, mj_dofs_idx, _, _) = _get_model_mappings(gs_sim, mj_sim)
+
+    qpos = np.array((0.1, -0.2))
+    init_simulators(gs_sim, mj_sim, qpos)
+
+    # Drive the tendon length toward a target on both simulators; controls persist across steps.
+    target = 1.2
+    gs_robot = gs_sim.entities[0]
+    gs_robot.solver.control_tendons_position(np.array([target]), tendons_idx=[gs_robot.get_tendon("t1").idx])
+    mj_sim.data.ctrl[:] = target
+
+    # Tolerance is a touch looser than the passive tests: the extra actuator-force projection introduces a small
+    # float-summation-order residual, but the per-step actuated dynamics still track MuJoCo to < 1e-6.
+    for _ in range(300):
+        # Re-sync to compare per-step dynamics (including the actuator transmission) rather than accumulated drift.
+        mj_sim.data.qpos[mj_qs_idx] = gs_sim.rigid_solver.qpos.to_numpy()[:, 0]
+        mj_sim.data.qvel[mj_dofs_idx] = gs_sim.rigid_solver.dofs_state.vel.to_numpy()[:, 0]
+        mujoco.mj_step(mj_sim.model, mj_sim.data)
+        gs_sim.scene.step()
+        gs_qpos = gs_sim.rigid_solver.qpos.to_numpy()[:, 0]
+        assert_allclose(gs_qpos, mj_sim.data.qpos[mj_qs_idx], atol=1e-6, rtol=1e-6)
 
 
 @pytest.mark.required


### PR DESCRIPTION
## Description

Implements MuJoCo-style **tendons** in the rigid solver, covering the full tendon feature set:

- **Fixed tendons** - linear joint couplings (`L = sum_i coef_i * qpos_i`): passive spring (with `[lo, hi]` deadband) + damping, length limits, frictionloss, and actuator transmission (position / velocity / force).
- **Spatial tendons** - geometric paths routed through **sites**, wrapping around **sphere/cylinder** geoms (with **sidesites**), and split by **pulleys**. Length and (configuration-dependent) moment arms are recomputed each step from link/geom kinematics.
- **Tendon-tendon equality** constraints (`mjEQ_TENDON`).
- A **site** abstraction (`SitesInfo` / `RigidSite`) for spatial routing anchors.
- Tendon **control API** (`control_tendons_{position,velocity,force}`, `get_tendons_length`) and a **debug visualization** of the spatial tendon path (`RigidEntity.draw_debug_tendons`).

Design note: fixed and spatial tendons are unified behind a per-step **moment row** - fixed tendons set it to the constant `coef`; spatial tendons compute it from point Jacobians over the path bodies' parent chains (shared-ancestor DOFs cancel to zero). The geom-wrapping geometry ports MuJoCo's `mju_wrap` / `wrap_circle` / `wrap_inside`. Wrap side selection is stateless (shortest-path, or biased to a sidesite), matching MuJoCo.

The previous MJCF importer approximated tendon actuators by collapsing them onto a single joint (`"Approximating tendon by joint actuator"`); that heuristic is removed in favor of real tendon support.

> [!NOTE]
> Stacked on #9 (`worktree-fix-mjcf-include-default-mesh`). Base that PR first; this PR's diff is tendon-only.

## Related Issue

No dedicated issue; happy to open one if preferred.

## Motivation and Context

Tendons are required to load and actuate common MuJoCo robots whose mechanics are tendon-driven (e.g. the Shadow Hand's coupled finger joints, the Franka gripper's `split` tendon). Genesis previously had no real tendon support - fixed tendons were approximated onto a single joint and spatial tendons were dropped entirely.

## How Has This Been / Can This Be Tested?

Added `tests/test_rigid_physics.py::test_tendon_*` (22 cases) cross-checking against MuJoCo via the existing `simulate_and_check_mujoco_consistency` harness (CPU, precision 64):

- `test_tendon_spring` / `test_tendon_damped` - passive spring / damping
- `test_tendon_limit` - length limits
- `test_tendon_actuator` - position-actuated fixed tendon
- `test_tendon_spatial` - site via-points + pulley
- `test_tendon_wrap` - sphere / cylinder geom wrapping
- `test_tendon_equality` - tendon-tendon equality

Spatial / wrap / actuator / equality track MuJoCo to `< 1e-6` per step; passive spring/limit to `1e-9`. Existing equality / IK / control / panda (tendon + equality) tests still pass.

```
pytest tests/test_rigid_physics.py -k tendon
```

Self-authored assets/examples (no external deps): `examples/rigid/tendon_arm.py` (scripted) and `examples/rigid/tendon_interaction.py` (interactive viewer + MouseInteraction drag + live tendon-path debug draw), driving `genesis/assets/xml/tendon_arm.xml`.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the documentation accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
